### PR TITLE
Trigger `onUse` for items in ComboMeleeState to start SwingArc effects

### DIFF
--- a/src/actors/player/states/combomeleeattackst.ts
+++ b/src/actors/player/states/combomeleeattackst.ts
@@ -546,6 +546,7 @@ export class ComboMeleeState extends AttackState implements IPlayerAction {
         const handItem = this.playerCtrl.baseSpec.GetBindItem(Bind.Hands_R);
         if (handItem) {
             (handItem as Item).activate?.();
+            (handItem as Item).trigger?.("onUse");
             if ((handItem as any).Sound) {
                 this.eventCtrl.SendEventMessage(EventTypes.RegisterSound, (handItem as any).Mesh, (handItem as any).Sound);
             }


### PR DESCRIPTION
### Motivation
- Combo melee steps called `activate()` on the equipped item but did not call `trigger("onUse")`, so effects that start on the `onUse` trigger (e.g. `SwingArcEffectAction`) were initialized but never started during combos.

### Description
- Added a call to `trigger("onUse")` on the bound hand item in `ComboMeleeState.startStep()` immediately after `activate()` so item VFX (like the swing arc trail) are started when a combo step begins.

### Testing
- Attempted `npm run build` to validate the change, but the build failed in this environment due to missing tooling (`webpack: not found`), so no compile/run verification was possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69979507f3348323881d2db8a67875b7)