### PR TITLE
Fix swing effect initialization and ensure `onUse` triggers trail start

### DIFF
--- a/src/actions/itemactions/swingarcact.ts
+++ b/src/actions/itemactions/swingarcact.ts
@@ -18,6 +18,7 @@ export default class SwingArcEffectAction implements IActionComponent, ILoop {
     apply(target: any) {
     }
     trigger(target: IActionUser, triggerType: TriggerType, context?: ActionContext | undefined): void {
+        if (!this.trail) this.activate(target, context)
         if (!this.trail) return
         if(triggerType === "onUse") {
             this.trail.start()

--- a/src/actions/itemactions/swingarcact.ts
+++ b/src/actions/itemactions/swingarcact.ts
@@ -12,33 +12,36 @@ export default class SwingArcEffectAction implements IActionComponent, ILoop {
         private eventCtrl: IEventController,
         private scene: THREE.Scene,
         private socketA: string = "localTipAOffset", // 기본값
-        private socketB: string = "localTipAOffset", // 기본값
+        private socketB: string = "localTipBOffset", // 기본값
     ) { }
 
     apply(target: any) {
     }
     trigger(target: IActionUser, triggerType: TriggerType, context?: ActionContext | undefined): void {
+        if (!this.trail) return
         if(triggerType === "onUse") {
-            this.trail!.start()
+            this.trail.start()
 
         } else if(triggerType === "onUnuse") {
-            this.trail!.stop()
+            this.trail.stop()
         }
     }
     activate(target: IActionUser, context?: ActionContext | undefined): void {
         const obj = target.objs
         if (!obj) return
-        const tipA = obj.getObjectByName(this.socketA)!
-        const tipB = obj.getObjectByName(this.socketB)!
+        const tipA = obj.getObjectByName(this.socketA)
+        const tipB = obj.getObjectByName(this.socketB)
+        if (!tipA || !tipB) return
 
-        if(!this.trail) 
+        if(!this.trail) {
             this.trail = new ArcTrailEffect(tipA, tipB, {
                 coreColor: 0x00ffff,
                 bodyColor: 0x0088ff
             });
-        this.scene.add((this.trail))
-        this.eventCtrl.SendEventMessage(EventTypes.RegisterLoop, this)
-        console.log("Swing Effect Activated")
+            this.scene.add(this.trail)
+            this.eventCtrl.SendEventMessage(EventTypes.RegisterLoop, this)
+            console.log("Swing Effect Activated")
+        }
     }
     deactivate(target: IActionUser, context?: ActionContext | undefined): void {
         this.eventCtrl.SendEventMessage(EventTypes.DeregisterLoop, this)
@@ -47,7 +50,8 @@ export default class SwingArcEffectAction implements IActionComponent, ILoop {
     }
     clock = new THREE.Clock()
     update(delta: number): void {
-        this.trail!.update(delta, this.clock.elapsedTime)
+        if (!this.trail) return
+        this.trail.update(delta, this.clock.getElapsedTime())
     }
 }
 

--- a/src/actions/itemactions/swingeffact.ts
+++ b/src/actions/itemactions/swingeffact.ts
@@ -18,6 +18,7 @@ export default class SwingEffectAction implements IActionComponent, ILoop {
     apply(target: any) {
     }
     trigger(target: IActionUser, triggerType: TriggerType, context?: ActionContext | undefined): void {
+        if (!this.trail) this.activate(target, context)
         if (!this.trail) return
         if(triggerType === "onUse") {
             this.trail.startTrail()

--- a/src/actions/itemactions/swingeffact.ts
+++ b/src/actions/itemactions/swingeffact.ts
@@ -12,36 +12,40 @@ export default class SwingEffectAction implements IActionComponent, ILoop {
         private eventCtrl: IEventController,
         private scene: THREE.Scene,
         private socketA: string = "localTipAOffset", // 기본값
-        private socketB: string = "localTipAOffset", // 기본값
+        private socketB: string = "localTipBOffset", // 기본값
     ) { }
 
     apply(target: any) {
     }
     trigger(target: IActionUser, triggerType: TriggerType, context?: ActionContext | undefined): void {
+        if (!this.trail) return
         if(triggerType === "onUse") {
-            this.trail!.startTrail()
+            this.trail.startTrail()
 
         } else if(triggerType === "onUnuse") {
-            this.trail!.stopTrail()
+            this.trail.stopTrail()
         }
     }
     activate(target: IActionUser, context?: ActionContext | undefined): void {
         const obj = target.objs
         if (!obj) return
-        const objA = obj.getObjectByName(this.socketA)!
-        const objB = obj.getObjectByName(this.socketB)!
+        const objA = obj.getObjectByName(this.socketA)
+        const objB = obj.getObjectByName(this.socketB)
+        if (!objA || !objB) return
 
-        if(!this.trail)
+        if(!this.trail) {
             this.trail = new WeaponTrail(this.scene, objA, objB)
-        this.eventCtrl.SendEventMessage(EventTypes.RegisterLoop, this)
-        console.log("Swing Effect Activated")
+            this.eventCtrl.SendEventMessage(EventTypes.RegisterLoop, this)
+            console.log("Swing Effect Activated")
+        }
     }
     deactivate(target: IActionUser, context?: ActionContext | undefined): void {
         this.eventCtrl.SendEventMessage(EventTypes.DeregisterLoop, this)
         console.log("Swing Effect Deactivated")
     }
     update(delta: number): void {
-        this.trail!.update(delta)
+        if (!this.trail) return
+        this.trail.update(delta)
     }
 }
 

--- a/src/actors/player/states/combomeleeattackst.ts
+++ b/src/actors/player/states/combomeleeattackst.ts
@@ -545,7 +545,9 @@ export class ComboMeleeState extends AttackState implements IPlayerAction {
         // 무기 세팅/오토에임
         const handItem = this.playerCtrl.baseSpec.GetBindItem(Bind.Hands_R);
         if (handItem) {
-            (handItem as Item).activate?.();
+            // 아이템 Action.activate는 장착 시점(PlayerCtrl.Equipment)에서 1회 호출됨
+            // 공격 시작/콤보 스텝에서는 onUse 트리거만 발행
+            (handItem as Item).trigger?.("onUse");
             if ((handItem as any).Sound) {
                 this.eventCtrl.SendEventMessage(EventTypes.RegisterSound, (handItem as any).Mesh, (handItem as any).Sound);
             }


### PR DESCRIPTION
### Motivation
- The Swing/SwingArc trail effects sometimes failed to start because `activate()` was being invoked at equip-time against the player object which may not contain weapon tip sockets, leaving `trail` uninitialized when later `onUse` was sent. 
- Ensure the combo attack lifecycle uses `onUse` to start runtime VFX and avoid dereferencing uninitialized `trail` objects. 
- Correct the wrong default for the second socket which could cause incorrect socket lookup.

### Description
- In `src/actions/itemactions/swingarcact.ts` and `src/actions/itemactions/swingeffact.ts` corrected the default `socketB` from `localTipAOffset` to `localTipBOffset` and removed unsafe non-null assertions. 
- Added defensive checks so `activate()` only creates and registers the trail when both `socketA` and `socketB` exist, and `trigger()`/`update()` now guard against `trail` being undefined. 
- In `src/actors/player/states/combomeleeattackst.ts` replaced the per-step `activate` usage with `trigger?.("onUse")` and added a clarifying comment that `activate()` runs at equip-time, while `onUse` is used for runtime attack effects. 

### Testing
- Attempted `npm run build` to validate the change but the build failed in this environment because `webpack` is not installed (`sh: 1: webpack: not found`).
- No other automated tests were available/run in this environment; changes were committed after local code modifications and basic runtime guards were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69979507f3348323881d2db8a67875b7)