### PR TITLE
Add Meteor skill and shared FireballCore; refactor fireball model and fix projectile movement

### DIFF
--- a/src/actions/actionregisterinit.ts
+++ b/src/actions/actionregisterinit.ts
@@ -17,6 +17,7 @@ import { FireballDefenceAction } from "./skillactions/firedefenceact";
 import { ElectricDefenceAction } from "./skillactions/electricdefenceact";
 import { GhostAction } from "./visualactions/ghostact";
 import { WaterDefenceAction } from "./skillactions/waterdefenceact";
+import { MeteorAction } from "./skillactions/meteoract";
 import SwingArcEffectAction from "./itemactions/swingarcact";
 
 export function InitActionRegistry(eventCtrl: EventController, scene: THREE.Scene, camera: Camera) {
@@ -24,6 +25,7 @@ export function InitActionRegistry(eventCtrl: EventController, scene: THREE.Scen
     ActionRegistry.register("hpStatBoost", def => new StatBoostAction(def))
     ActionRegistry.register("fireball", def => new FireballAction(eventCtrl, def))
     ActionRegistry.register("projectileFire", def => new FireballAction(eventCtrl, def))
+    ActionRegistry.register("meteor", def => new MeteorAction(eventCtrl, scene, def))
     ActionRegistry.register("casing", def => new BulletCasingAct(eventCtrl, scene, def.socket))
     ActionRegistry.register("muzzleFlash", def => {
         const texture = new THREE.TextureLoader().load(def.texture)

--- a/src/actions/actiontypes.ts
+++ b/src/actions/actiontypes.ts
@@ -228,6 +228,22 @@ export const actionDefs = {
       { damage: 20, radius: 1.5, speed: 10 }
     ]
   },
+  Meteor: {
+    id: "skill_meteor",
+    name: "Meteor",
+    trigger: "onCast",
+    type: "meteor",
+    cooldown: 7,
+    distance: 8,
+    fallDuration: 0.65,
+    ringRadius: 1.9,
+    ringCount: 6,
+    levels: [
+      { damage: 20, radius: 2.0 },
+      { damage: 28, radius: 2.4 },
+      { damage: 36, radius: 2.8 }
+    ]
+  },
   Heal: {
     id: "heal",
     name: "Heal",

--- a/src/actions/skillactions/meteoract.ts
+++ b/src/actions/skillactions/meteoract.ts
@@ -1,0 +1,169 @@
+import * as THREE from "three"
+import IEventController, { ILoop } from "@Glibs/interface/ievent"
+import { ActionContext, IActionComponent, IActionUser } from "@Glibs/types/actiontypes"
+import { ActionDef } from "../actiontypes"
+import { EventTypes } from "@Glibs/types/globaltypes"
+import { createFireballCore, FireballCore } from "@Glibs/magical/libs/fireballcore"
+
+type ActiveMeteor = {
+  core: FireballCore
+  start: THREE.Vector3
+  end: THREE.Vector3
+  elapsed: number
+  duration: number
+}
+
+type ActiveRingCore = {
+  core: FireballCore
+  ttl: number
+  age: number
+}
+
+export class MeteorAction implements IActionComponent, ILoop {
+  id = "skill_meteor"
+  LoopId = 0
+
+  private cooldown = 7000
+  private lastUsed = 0
+  private impactDistance = 8
+  private fallDuration = 0.65
+  private ringRadius = 1.9
+  private ringCount = 6
+
+  private activeMeteors: ActiveMeteor[] = []
+  private ringCores: ActiveRingCore[] = []
+
+  constructor(
+    private eventCtrl: IEventController,
+    private scene: THREE.Scene,
+    private def: ActionDef,
+  ) {
+    if (typeof def.cooldown === "number") this.cooldown = def.cooldown * 1000
+    if (typeof def.distance === "number") this.impactDistance = Math.max(3, def.distance)
+    if (typeof def.fallDuration === "number") this.fallDuration = Math.max(0.2, def.fallDuration)
+    if (typeof def.ringRadius === "number") this.ringRadius = Math.max(0.2, def.ringRadius)
+    if (typeof def.ringCount === "number") this.ringCount = Math.max(3, Math.floor(def.ringCount))
+
+    this.eventCtrl.SendEventMessage(EventTypes.RegisterLoop, this)
+  }
+
+  activate(_target: IActionUser, _context?: ActionContext) {}
+
+  trigger(target: IActionUser, triggerType: "onCast", context?: ActionContext) {
+    if (triggerType !== "onCast") return
+
+    const now = performance.now()
+    if (now - this.lastUsed < this.cooldown) return
+
+    const caster = this.getCasterObject(target)
+    if (!caster) return
+
+    const start = new THREE.Vector3()
+    const impact = new THREE.Vector3()
+
+    caster.getWorldPosition(impact)
+    const forward = this.resolveGroundForward(caster, context)
+    impact.addScaledVector(forward, this.impactDistance)
+    impact.y += 0.2
+
+    const right = new THREE.Vector3().crossVectors(forward, new THREE.Vector3(0, 1, 0)).normalize()
+    start.copy(impact)
+      .addScaledVector(forward, -5.5)
+      .addScaledVector(right, -2.2)
+    start.y += 14
+
+    const core = createFireballCore({ scale: 1.45 })
+    core.setPosition(start)
+    this.scene.add(core.root)
+
+    this.activeMeteors.push({
+      core,
+      start,
+      end: impact,
+      elapsed: 0,
+      duration: this.fallDuration,
+    })
+
+    this.spawnFireballRing(impact)
+    this.lastUsed = now
+  }
+
+  update(delta: number): void {
+    this.activeMeteors = this.activeMeteors.filter((m) => {
+      m.elapsed += delta
+      const t = Math.min(1, m.elapsed / m.duration)
+      const eased = 1 - Math.pow(1 - t, 3)
+      const pos = m.start.clone().lerp(m.end, eased)
+      m.core.setPosition(pos)
+      m.core.update(m.elapsed, delta)
+
+      if (t < 1) return true
+
+      this.scene.remove(m.core.root)
+      m.core.dispose()
+      return false
+    })
+
+    this.ringCores = this.ringCores.filter((entry) => {
+      entry.age += delta
+      entry.core.update(entry.age, delta)
+      const alpha = Math.max(0, 1 - (entry.age / entry.ttl))
+      entry.core.root.scale.setScalar(0.65 + alpha * 0.45)
+
+      if (entry.age < entry.ttl) return true
+
+      this.scene.remove(entry.core.root)
+      entry.core.dispose()
+      return false
+    })
+  }
+
+  isAvailable(): boolean {
+    return performance.now() - this.lastUsed >= this.cooldown
+  }
+
+  private spawnFireballRing(center: THREE.Vector3) {
+    for (let i = 0; i < this.ringCount; i++) {
+      const a = (i / this.ringCount) * Math.PI * 2
+      const p = new THREE.Vector3(
+        center.x + Math.cos(a) * this.ringRadius,
+        center.y + 0.2,
+        center.z + Math.sin(a) * this.ringRadius,
+      )
+      const core = createFireballCore({ scale: 0.6 })
+      core.setPosition(p)
+      this.scene.add(core.root)
+      this.ringCores.push({ core, ttl: 0.55, age: 0 })
+    }
+  }
+
+  private getCasterObject(target: IActionUser): THREE.Object3D | undefined {
+    const obj = target.objs
+    if (!obj) return
+    if (obj instanceof THREE.Object3D) return obj
+    return
+  }
+
+  private resolveGroundForward(caster: THREE.Object3D, context?: ActionContext) {
+    const fromContext = this.asVector3(context?.direction)
+    if (fromContext && fromContext.lengthSq() > 0.000001) {
+      const d = fromContext.clone()
+      d.y = 0
+      if (d.lengthSq() > 0.000001) return d.normalize()
+    }
+
+    const forward = new THREE.Vector3()
+    caster.getWorldDirection(forward)
+    forward.y = 0
+    if (forward.lengthSq() < 0.000001) return new THREE.Vector3(0, 0, 1)
+    return forward.normalize()
+  }
+
+  private asVector3(value: unknown): THREE.Vector3 | undefined {
+    if (value instanceof THREE.Vector3) return value
+    const candidate = value as { x?: unknown; y?: unknown; z?: unknown } | undefined
+    if (!candidate) return
+    if (typeof candidate.x !== "number" || typeof candidate.y !== "number" || typeof candidate.z !== "number") return
+    return new THREE.Vector3(candidate.x, candidate.y, candidate.z)
+  }
+}

--- a/src/actors/battle/stats.ts
+++ b/src/actors/battle/stats.ts
@@ -143,8 +143,12 @@ export const baseStatPresets: Record<MonsterIdType, Partial<Record<StatKey, numb
     'attack': 2,
     'speed': 10.0
   },
+  [MonsterId.Fireball]: {
+    hp: 1,
+    attack: 8,
+    speed: 10.0,
+  },
 };
 
 
 export type MonsterGrade = 'normal' | 'elite' | 'boss';
-

--- a/src/actors/projectile/fireballmodel.ts
+++ b/src/actors/projectile/fireballmodel.ts
@@ -1,186 +1,40 @@
 import * as THREE from "three";
 import { IProjectileModel } from "./projectile";
-
-export interface FireballConfig {
-    particleCount: number;
-    radius: number;
-    riseSpeed: number;
-    expansionSpeed: number;
-    turbulence: number;
-    baseScale: number;
-    lifeTime: number;
-    opacity: number;
-    coreColor: string;
-    midColor: string;
-    edgeColor: string;
-}
-
-export type FireballParticle = THREE.Sprite & { 
-    userData: { life: number; age: number; velocity: THREE.Vector3; noiseOffset: number; } 
-};
+import { createFireballCore, FireballCore } from "@Glibs/magical/libs/fireballcore";
 
 export class FireballModel implements IProjectileModel {
     private group: THREE.Group;
-    private emitter: THREE.Mesh;
-    private particles: FireballParticle[] = [];
-    private particleTexture: THREE.CanvasTexture;
-    private config: FireballConfig;
+    private core: FireballCore;
     private clock: THREE.Clock;
-    private alive: boolean = false;
+    private alive = false;
 
-    // 기존 시스템에서 가져가 렌더링할 루트 오브젝트
     get Meshs() { return this.group; }
 
-    constructor(initialConfig?: Partial<FireballConfig>) {
+    constructor() {
         this.group = new THREE.Group();
-        this.clock = new THREE.Clock();
-        
-        this.config = {
-            particleCount: 200, // 최적화를 위해 약간 낮춤
-            radius: 0.8,
-            riseSpeed: 1.5,
-            expansionSpeed: 0.5,
-            turbulence: 1.5,
-            baseScale: 1.0,
-            lifeTime: 0.6,
-            opacity: 0.7,
-            coreColor: '#ffffcc',
-            midColor: '#ff9900',
-            edgeColor: '#ff2200',
-            ...initialConfig
-        };
-
-        this.particleTexture = this.createHexagonTexture();
-        
-        // Emitter (투명한 본체 + 코어 라이트)
-        this.emitter = new THREE.Mesh(
-            new THREE.SphereGeometry(0.3),
-            new THREE.MeshBasicMaterial({ visible: false })
-        );
-        const coreLight = new THREE.PointLight(0xffaa00, 20, 10);
-        this.emitter.add(coreLight);
-        this.group.add(this.emitter);
-
-        this.initParticles();
+        this.core = createFireballCore({ scale: 1 });
+        this.group.add(this.core.root);
         this.group.visible = false;
+        this.clock = new THREE.Clock();
     }
 
-    private createHexagonTexture(): THREE.CanvasTexture {
-        const size = 64;
-        const canvas = document.createElement('canvas');
-        canvas.width = canvas.height = size;
-        const ctx = canvas.getContext('2d')!;
-        const radius = size / 2 * 0.9;
-        
-        ctx.beginPath();
-        for (let i = 0; i < 6; i++) {
-            const angle = (Math.PI / 3) * i;
-            const x = size / 2 + radius * Math.cos(angle);
-            const y = size / 2 + radius * Math.sin(angle);
-            if (i === 0) ctx.moveTo(x, y);
-            else ctx.lineTo(x, y);
-        }
-        ctx.closePath();
-        ctx.fillStyle = 'white';
-        ctx.fill();
-        return new THREE.CanvasTexture(canvas);
-    }
-
-    private initParticles() {
-        for (let i = 0; i < this.config.particleCount; i++) {
-            const mat = new THREE.SpriteMaterial({
-                map: this.particleTexture,
-                color: 0xffffff,
-                transparent: true,
-                opacity: 0,
-                blending: THREE.AdditiveBlending,
-                depthWrite: false
-            });
-            const sprite = new THREE.Sprite(mat) as FireballParticle;
-            sprite.userData = {
-                life: 0, age: 0, velocity: new THREE.Vector3(), noiseOffset: Math.random() * 100
-            };
-            this.group.add(sprite);
-            this.particles.push(sprite);
-        }
-    }
-
-    private spawnParticle(sprite: FireballParticle) {
-        sprite.userData.age = 0;
-        sprite.userData.life = Math.random() * this.config.lifeTime + 0.2;
-
-        const center = this.emitter.position;
-        const r = Math.pow(Math.random(), 1 / 3) * this.config.radius;
-        const theta = Math.random() * Math.PI * 2;
-        const phi = Math.acos(2 * Math.random() - 1);
-
-        const offsetX = r * Math.sin(phi) * Math.cos(theta);
-        const offsetY = r * Math.sin(phi) * Math.sin(theta);
-        const offsetZ = r * Math.cos(phi);
-
-        sprite.position.set(center.x + offsetX, center.y + offsetY, center.z + offsetZ);
-        sprite.userData.velocity.set(offsetX * 2, offsetY * 2 + Math.random() * 2, offsetZ * 2).normalize();
-        sprite.material.rotation = Math.random() * Math.PI;
-    }
-
-    // IProjectileModel 구현: 발사 시작
     create(position: THREE.Vector3): void {
-        this.emitter.position.copy(position);
         this.group.visible = true;
         this.alive = true;
         this.clock.start();
-
-        // 파티클 초기화
-        this.particles.forEach(p => this.spawnParticle(p));
+        this.group.position.copy(position);
     }
 
-    // IProjectileModel 구현: 매 프레임 위치 갱신 및 이펙트 업데이트
     update(position: THREE.Vector3): void {
         if (!this.alive) return;
-
         const delta = this.clock.getDelta();
-        const time = this.clock.getElapsedTime();
-
-        // 컨트롤러가 계산한 현재 위치를 Emitter에 적용
-        this.emitter.position.copy(position);
-
-        const colorCore = new THREE.Color(this.config.coreColor);
-        const colorMid = new THREE.Color(this.config.midColor);
-        const colorEdge = new THREE.Color(this.config.edgeColor);
-
-        // 파티클 잔상 효과 업데이트
-        this.particles.forEach(sprite => {
-            const u = sprite.userData;
-            u.age += delta;
-
-            if (u.age > u.life) this.spawnParticle(sprite);
-
-            sprite.position.x += u.velocity.x * this.config.expansionSpeed * delta;
-            sprite.position.y += (u.velocity.y + this.config.riseSpeed) * delta;
-            sprite.position.z += u.velocity.z * this.config.expansionSpeed * delta;
-
-            sprite.position.x += Math.sin(time * 5 + u.noiseOffset) * delta * this.config.turbulence;
-            sprite.position.y += Math.cos(time * 3 + u.noiseOffset) * delta * this.config.turbulence;
-
-            const lifeRatio = u.age / u.life;
-            const scaleCurve = Math.sin(lifeRatio * Math.PI);
-
-            let scale = scaleCurve * this.config.baseScale * (1 + lifeRatio * 1.5);
-            sprite.scale.set(scale, scale, scale);
-            sprite.material.opacity = this.config.opacity * scaleCurve;
-
-            let finalColor = colorCore.clone();
-            if (lifeRatio < 0.3) finalColor.lerp(colorMid, lifeRatio / 0.3);
-            else finalColor.copy(colorMid).lerp(colorEdge, (lifeRatio - 0.3) / 0.7);
-            
-            sprite.material.color.copy(finalColor);
-        });
+        const elapsed = this.clock.getElapsedTime();
+        this.group.position.copy(position);
+        this.core.update(elapsed, delta);
     }
 
-    // IProjectileModel 구현: 폭발/소멸 처리
     release(): void {
         this.alive = false;
         this.group.visible = false;
-        // 필요시 폭발 이펙트를 발생시키는 이벤트를 호출할 수도 있습니다.
     }
 }

--- a/src/actors/projectile/projectilectrl.ts
+++ b/src/actors/projectile/projectilectrl.ts
@@ -63,11 +63,15 @@ export class ProjectileCtrl implements IActionUser {
     }
     update(delta: number): void {
         if (!this.live) return
-        const mov = this.baseSpec.Speed * delta
+        const dirLen = this.moveDirection.length()
+        if (dirLen <= 0.000001) return
+
+        const speed = Math.max(0.1, this.baseSpec.Speed) * Math.max(0.1, dirLen)
+        const mov = speed * delta
         this.currenttime += delta
         this.moving += mov
         this.prevPosition.copy(this.position)
-        this.position.addScaledVector(this.moveDirection, mov);
+        this.position.addScaledVector(this.moveDirection, mov / dirLen);
 
         this.projectile.update(this.position)
     }

--- a/src/magical/libs/fireballcore.ts
+++ b/src/magical/libs/fireballcore.ts
@@ -1,0 +1,99 @@
+import * as THREE from "three"
+
+export type FireballCoreOptions = {
+  scale?: number
+  colorCore?: THREE.ColorRepresentation
+  colorAura?: THREE.ColorRepresentation
+  colorRing?: THREE.ColorRepresentation
+}
+
+export class FireballCore {
+  readonly root: THREE.Group
+
+  private core: THREE.Mesh
+  private aura: THREE.Mesh
+  private rings: THREE.Mesh[] = []
+  private rotSpeed: number[] = []
+
+  constructor(options: FireballCoreOptions = {}) {
+    const scale = options.scale ?? 1
+
+    this.root = new THREE.Group()
+
+    this.core = new THREE.Mesh(
+      new THREE.SphereGeometry(0.26 * scale, 20, 20),
+      new THREE.MeshBasicMaterial({
+        color: options.colorCore ?? "#ffd7a3",
+        transparent: true,
+        opacity: 0.95,
+      }),
+    )
+
+    this.aura = new THREE.Mesh(
+      new THREE.SphereGeometry(0.42 * scale, 18, 18),
+      new THREE.MeshBasicMaterial({
+        color: options.colorAura ?? "#ff6a00",
+        transparent: true,
+        opacity: 0.42,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+      }),
+    )
+
+    this.root.add(this.core, this.aura)
+
+    for (let i = 0; i < 3; i++) {
+      const ring = new THREE.Mesh(
+        new THREE.RingGeometry(0.34 * scale, 0.43 * scale, 32),
+        new THREE.MeshBasicMaterial({
+          color: options.colorRing ?? "#ffb347",
+          transparent: true,
+          opacity: 0.5,
+          blending: THREE.AdditiveBlending,
+          side: THREE.DoubleSide,
+          depthWrite: false,
+        }),
+      )
+      ring.rotation.set(Math.random() * Math.PI, Math.random() * Math.PI, Math.random() * Math.PI)
+      this.rotSpeed.push(0.5 + Math.random() * 1.3)
+      this.rings.push(ring)
+      this.root.add(ring)
+    }
+
+    const light = new THREE.PointLight(0xff8a2a, 3, 8)
+    this.root.add(light)
+  }
+
+  setPosition(position: THREE.Vector3) {
+    this.root.position.copy(position)
+  }
+
+  update(elapsedSec: number, deltaSec: number) {
+    const pulse = 1 + Math.sin(elapsedSec * 8) * 0.06
+    this.aura.scale.setScalar(pulse)
+
+    this.rings.forEach((ring, i) => {
+      const spin = this.rotSpeed[i] * deltaSec
+      ring.rotation.x += spin
+      ring.rotation.y -= spin * 0.7
+      ring.rotation.z += spin * 0.45
+      ;(ring.material as THREE.MeshBasicMaterial).opacity = 0.32 + Math.sin(elapsedSec * 6 + i) * 0.14
+    })
+  }
+
+  dispose() {
+    const disposeNode = (obj: THREE.Object3D) => {
+      const mesh = obj as THREE.Mesh
+      mesh.geometry?.dispose?.()
+      const mat = mesh.material as THREE.Material | THREE.Material[] | undefined
+      if (Array.isArray(mat)) mat.forEach((m) => m.dispose())
+      else mat?.dispose?.()
+    }
+
+    this.root.traverse(disposeNode)
+  }
+}
+
+export function createFireballCore(options?: FireballCoreOptions) {
+  return new FireballCore(options)
+}

--- a/src/techtree/techtreedefs.ts
+++ b/src/techtree/techtreedefs.ts
@@ -426,7 +426,7 @@ export const DefaultTechTreeDefs: TechTreeDefBase[] = [
         tags: ["fire", "aoe"],
         requires: [{ type: "has", id: "skill_fireball", minLv: 1 }],
         cost: COST_1,
-        tech: MOCK_TECH
+        tech: actionDefs.Meteor
     },
 
     // --- 냉기 (Ice) ---


### PR DESCRIPTION
### Motivation
- Provide a reusable visual primitive for fireball-like effects so multiple skills can share the same VFX code and avoid duplication.
- Implement a new `skill_meteor` action that spawns a slanted sky-fall fireball and a ring of fireball cores at the impact point in front of the caster.
- Make projectile motion robust by ensuring movement follows the controller's direction magnitude and by preventing zero-length direction updates.

### Description
- Added a reusable fireball primitive `FireballCore` in `src/magical/libs/fireballcore.ts` which encapsulates core/aura/ring meshes, animation, and disposal logic.
- Refactored `FireballModel` (`src/actors/projectile/fireballmodel.ts`) to use `createFireballCore` so projectile visuals follow `ProjectileCtrl` position updates directly.
- Implemented `MeteorAction` (`src/actions/skillactions/meteoract.ts`) which spawns a slanted falling fireball core from the sky and a circular ring of smaller cores at the impact location.
- Registered the new action type in `InitActionRegistry` (`src/actions/actionregisterinit.ts`) and added `actionDefs.Meteor` to `src/actions/actiontypes.ts`, then wired the tech tree node `skill_meteor` to use it in `src/techtree/techtreedefs.ts`.
- Adjusted `ProjectileCtrl.update` (`src/actors/projectile/projectilectrl.ts`) to handle zero-length directions and to scale speed by the direction vector magnitude while keeping path updates normalized.
- Added a base stat preset for the fireball monster in `src/actors/battle/stats.ts` so projectiles have a sensible `Speed` fallback.

### Testing
- Ran a local static server (`python -m http.server 4173`) and captured a runtime screenshot with a Playwright script pointing at `http://127.0.0.1:4173/index.html`, which completed successfully and produced a screenshot artifact.
- Attempted `npm run -s build`, which failed in this environment due to `webpack` not being installed (`sh: 1: webpack: not found`).
- Verified code-level wiring via repository searches and inspected modified files to ensure registry, action type, and techtree references were updated as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997e2b17b888323beef65b7d8c86495)