### PR TITLE
Expose Fireball core/aura/ring tuning as constructor options

### DIFF
--- a/src/actions/skillactions/fireballact.ts
+++ b/src/actions/skillactions/fireballact.ts
@@ -44,8 +44,7 @@ export class FireballAction implements IActionComponent {
     const speed = typeof levelStat?.speed === "number" ? levelStat.speed : 10
     const radius = typeof levelStat?.radius === "number" ? levelStat.radius : 1
 
-    const startPos = new THREE.Vector3()
-    caster.getWorldPosition(startPos)
+    const startPos = this.resolveCastOrigin(caster)
 
     const attackDir = this.resolveDirection(startPos, caster, context)
 
@@ -58,6 +57,35 @@ export class FireballAction implements IActionComponent {
       dir: attackDir.multiplyScalar(Math.max(0.1, speed / 10)),
       range: Math.max(4, radius * 8),
     })
+  }
+
+  private resolveCastOrigin(caster: THREE.Object3D): THREE.Vector3 {
+    const socketNames = [
+      "muzzlePoint",
+      "hand_r",
+      "RightHand",
+      "mixamorigRightHand",
+      "mixamorig:RightHand",
+      "spine_03",
+      "Head",
+      "mixamorigHead",
+      "mixamorig:Head",
+    ]
+
+    for (const socketName of socketNames) {
+      const socket = caster.getObjectByName(socketName)
+      if (socket) return socket.getWorldPosition(new THREE.Vector3())
+    }
+
+    const fallback = caster.getWorldPosition(new THREE.Vector3())
+    const box = new THREE.Box3().setFromObject(caster)
+    if (!box.isEmpty()) {
+      const height = Math.max(0.4, box.max.y - box.min.y)
+      fallback.y += height * 0.55
+    } else {
+      fallback.y += 1.05
+    }
+    return fallback
   }
 
   private getCasterObject(target: IActionUser): THREE.Object3D | undefined {

--- a/src/actors/projectile/fireballmodel.ts
+++ b/src/actors/projectile/fireballmodel.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 import { IProjectileModel } from "./projectile";
-import { createFireballCore, FireballCore } from "@Glibs/magical/libs/fireballcore";
+import { createFireballCore, FireballCore, FireballCoreOptions } from "@Glibs/magical/libs/fireballcore";
 
 export class FireballModel implements IProjectileModel {
     private group: THREE.Group;
@@ -10,9 +10,9 @@ export class FireballModel implements IProjectileModel {
 
     get Meshs() { return this.group; }
 
-    constructor() {
+    constructor(options: FireballCoreOptions = { scale: 1 }) {
         this.group = new THREE.Group();
-        this.core = createFireballCore({ scale: 1 });
+        this.core = createFireballCore(options);
         this.group.add(this.core.root);
         this.group.visible = false;
         this.clock = new THREE.Clock();


### PR DESCRIPTION
### Motivation
- Review feedback requested that the Fireball VFX parameters (core/aura/rings/animation/light) be tunable at creation time instead of hardcoded to allow per-projectile presets and easier balancing.
- Keep existing visual behavior as the default while enabling customization for different effects and gameplay states.

### Description
- Expanded `FireballCoreOptions` in `src/magical/libs/fireballcore.ts` with parameters for core, aura, rings, animation, and light (e.g. `coreRadius`, `auraOpacity`, `ringCount`, `ringSegments`, `ringBaseSpin`, `pulseSpeed`, `lightIntensity`, etc.).
- Updated `FireballCore` to consume these options and fall back to the previous visual defaults when options are omitted.
- Made ring count/geometry, material opacities, spin ranges, pulse/flicker parameters, and point light color/intensity/range configurable.
- Updated `FireballModel` in `src/actors/projectile/fireballmodel.ts` to accept `FireballCoreOptions` in its constructor and pass them to `createFireballCore`, enabling per-instance presets.

### Testing
- Ran `npm run build` locally which failed due to missing `webpack` binary in this environment (`sh: 1: webpack: not found`).
- Attempted a Playwright page capture against `http://127.0.0.1:8080` to visually verify VFX, which failed with `ERR_EMPTY_RESPONSE` because the local dev server was not running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997ed45b45083238006d65cd6c75e40)