### PR TITLE
Fix fireball projectile particle space behavior

### DIFF
--- a/src/actors/projectile/fireballmodel.ts
+++ b/src/actors/projectile/fireballmodel.ts
@@ -3,38 +3,35 @@ import { IProjectileModel } from "./projectile";
 import { createFireballCore, FireballCore, FireballCoreOptions } from "@Glibs/magical/libs/fireballcore";
 
 export class FireballModel implements IProjectileModel {
-    private group: THREE.Group;
     private core: FireballCore;
     private clock: THREE.Clock;
     private alive = false;
 
-    get Meshs() { return this.group; }
+    get Meshs() { return this.core.root; }
 
     constructor(options: FireballCoreOptions = { scale: 1 }) {
-        this.group = new THREE.Group();
         this.core = createFireballCore(options);
-        this.group.add(this.core.root);
-        this.group.visible = false;
+        this.core.root.visible = false;
         this.clock = new THREE.Clock();
     }
 
     create(position: THREE.Vector3): void {
-        this.group.visible = true;
+        this.core.root.visible = true;
         this.alive = true;
         this.clock.start();
-        this.group.position.copy(position);
+        this.core.setPosition(position);
     }
 
     update(position: THREE.Vector3): void {
         if (!this.alive) return;
         const delta = this.clock.getDelta();
         const elapsed = this.clock.getElapsedTime();
-        this.group.position.copy(position);
+        this.core.setPosition(position);
         this.core.update(elapsed, delta);
     }
 
     release(): void {
         this.alive = false;
-        this.group.visible = false;
+        this.core.root.visible = false;
     }
 }


### PR DESCRIPTION
### Motivation
- Particles emitted by `FireballCore` were being translated as a single local cluster because `FireballModel` wrapped `core.root` in a moving `Group`, so the goal is to have particles move in world space while keeping the emitter position updated.

### Description
- Removed the extra wrapper `Group` in `FireballModel`, exposed `core.root` via `get Meshs()`, and replaced `group.position`/`group.visible` usage with `core.setPosition(...)` and `core.root.visible` to keep particle sprites in world coordinates (`src/actors/projectile/fireballmodel.ts`).

### Testing
- Ran the build command `npm run build` and it failed in this environment because the `webpack` binary is not installed (`sh: 1: webpack: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997f1065e008323b017da6024d3a3a1)