### PR TITLE
Reset fireball particles on respawn to fix artifact

### DIFF
--- a/src/actors/projectile/fireballmodel.ts
+++ b/src/actors/projectile/fireballmodel.ts
@@ -19,7 +19,7 @@ export class FireballModel implements IProjectileModel {
         this.core.root.visible = true;
         this.alive = true;
         this.clock.start();
-        this.core.setPosition(position);
+        this.core.reset(position);
     }
 
     update(position: THREE.Vector3): void {

--- a/src/magical/libs/fireballcore.ts
+++ b/src/magical/libs/fireballcore.ts
@@ -88,6 +88,11 @@ export class FireballCore {
     this.emitter.position.copy(position)
   }
 
+  reset(position: THREE.Vector3) {
+    this.setPosition(position)
+    this.particles.forEach((sprite) => this.spawnParticle(sprite))
+  }
+
   update(elapsedSec: number, deltaSec: number) {
     this.particles.forEach((sprite) => {
       const u = sprite.userData


### PR DESCRIPTION
### Motivation
- Fireball projectiles are pooled and on reuse only the emitter was moved while existing particle sprites retained their previous world positions, causing the effect to briefly appear at the prior impact point before moving.

### Description
- Add `FireballCore.reset(position)` to reposition the emitter and respawn all particles, and update `FireballModel.create()` to call `core.reset(position)` instead of `core.setPosition(position)`.

### Testing
- Ran the project build via `npm run build`, which failed in this environment due to a missing `webpack` binary (`sh: 1: webpack: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998045ca6b48323b4a6ceb6b5f54523)