### PR TITLE
Scale projectile hit radius by monster size and wire attack stat boost tech

### DIFF
--- a/src/actions/actionregisterinit.ts
+++ b/src/actions/actionregisterinit.ts
@@ -23,6 +23,7 @@ import SwingArcEffectAction from "./itemactions/swingarcact";
 export function InitActionRegistry(eventCtrl: EventController, scene: THREE.Scene, camera: Camera) {
     ActionRegistry.register("statBoost", def => new StatBoostAction(def))
     ActionRegistry.register("hpStatBoost", def => new StatBoostAction(def))
+    ActionRegistry.register("attackStatBoost", def => new StatBoostAction(def))
     ActionRegistry.register("fireball", def => new FireballAction(eventCtrl, def))
     ActionRegistry.register("projectileFire", def => new FireballAction(eventCtrl, def))
     ActionRegistry.register("meteor", def => new MeteorAction(eventCtrl, scene, def))

--- a/src/actions/actiontypes.ts
+++ b/src/actions/actiontypes.ts
@@ -104,7 +104,9 @@ export const actionDefs = {
     levels: [
       { attack: 3, },
       { attack: 5, },
-      { attack: 10, }
+      { attack: 7, },
+      { attack: 10, },
+      { attack: 14, }
     ]
   },
   // =================================================================

--- a/src/actions/skillactions/fireballact.ts
+++ b/src/actions/skillactions/fireballact.ts
@@ -48,6 +48,12 @@ export class FireballAction implements IActionComponent {
 
     const attackDir = this.resolveDirection(startPos, caster, context)
 
+    const defaultRange = Math.max(12, radius * 24)
+    const destination = this.asVector3(context?.destination)
+    const range = destination
+      ? Math.max(defaultRange, startPos.distanceTo(destination) + radius * 2)
+      : defaultRange
+
     this.lastUsed = now
     this.eventCtrl.SendEventMessage(EventTypes.Projectile, {
       id: MonsterId.Fireball,
@@ -55,7 +61,7 @@ export class FireballAction implements IActionComponent {
       damage,
       src: startPos,
       dir: attackDir.multiplyScalar(Math.max(0.1, speed / 10)),
-      range: Math.max(12, radius * 24),
+      range,
     })
   }
 

--- a/src/actions/traitaction/statboostact.ts
+++ b/src/actions/traitaction/statboostact.ts
@@ -19,9 +19,13 @@ export class StatBoostAction implements IActionComponent {
     if ("stats" in this.def) {
       this.modifiers = Object.entries(this.def.stats).map(([stat, value]) =>
         new Modifier(stat as StatKey, value! as number, this.type, this.source))
-     } else {
-      const level = context?.level ?? 0
-      this.modifiers = Object.entries(this.def.levels[level]).map(([stat, value]) =>
+    } else {
+      const levels = Array.isArray(this.def.levels) ? this.def.levels : []
+      if (levels.length === 0) return
+
+      const currentLevel = Math.max(1, context?.level ?? 1)
+      const levelIndex = Math.min(levels.length - 1, currentLevel - 1)
+      this.modifiers = Object.entries(levels[levelIndex]).map(([stat, value]) =>
         new Modifier(stat as StatKey, value! as number, this.type, this.source))
     }
 

--- a/src/actors/projectile/projectilectrl.ts
+++ b/src/actors/projectile/projectilectrl.ts
@@ -15,7 +15,7 @@ export class ProjectileCtrl implements IActionUser {
     moveDirection = new THREE.Vector3()
     prevPosition = new THREE.Vector3()
     position = new THREE.Vector3()
-    attackDist = 2
+    attackDist = 1
     maxTarget = 1
     currenttime = 0
     live = false
@@ -143,6 +143,14 @@ export class ProjectileCtrl implements IActionUser {
 
         return closest.distanceTo(sphereCenter) <= sphereRadius;
     }
+
+    private getTargetRadius(target: THREE.Object3D): number {
+        const box = new THREE.Box3().setFromObject(target)
+        if (box.isEmpty()) return 0
+
+        const sphere = box.getBoundingSphere(new THREE.Sphere())
+        return Math.max(0, sphere.radius)
+    }
     getClosestHit(
         p1: THREE.Vector3,
         p2: THREE.Vector3,
@@ -164,8 +172,9 @@ export class ProjectileCtrl implements IActionUser {
             // 충돌 지점 계산
             const closestPoint = p1.clone().add(segDir.clone().multiplyScalar(projLen));
             const distToCenter = closestPoint.distanceTo(center);
+            const targetRadius = this.getTargetRadius(target) + radius;
 
-            if (distToCenter <= radius) {
+            if (distToCenter <= targetRadius) {
                 const distFromStart = p1.distanceTo(closestPoint);
                 if (!closest || distFromStart < closest.distance) {
                     closest = {

--- a/src/techtree/techtreedefs.ts
+++ b/src/techtree/techtreedefs.ts
@@ -156,7 +156,7 @@ export const DefaultTechTreeDefs: TechTreeDefBase[] = [
         tags: ["stat", "attack"],
         requires: [{ type: "has", id: "root_license" }],
         cost: COST_5,
-        tech: MOCK_TECH
+        tech: actionDefs.AttackStatBoost
     },
     {
         id: "stat_proj_speed",


### PR DESCRIPTION
### Motivation
- Prevent fireball (and similar projectiles) from detonating too early by using a per-target size-aware hit radius instead of an oversized fixed radius.
- Ensure the `stat_might` tech is backed by a real attack stat action and that stat-level handling is robust at runtime.
- Make projectile travel distance for fireball more sensible with respect to configured radius and explicit destination.

### Description
- Projectile collision: changed `attackDist` from `2` to `1`, added `getTargetRadius(target: THREE.Object3D)` and updated `getClosestHit` to test against `getTargetRadius(target) + radius` so collisions scale with the target bounding sphere plus padding (`src/actors/projectile/projectilectrl.ts`).
- Fireball behavior: compute a `defaultRange` from `radius` and `speed`, and compute `range` that respects an explicit `destination` so fireballs travel far enough relative to their radius (`src/actions/skillactions/fireballact.ts`).
- Action registry: register `attackStatBoost` so `ActionRegistry.create` can produce attack stat boost actions (`src/actions/actionregisterinit.ts`).
- Action defs: expand `AttackStatBoost` levels to a 5-step progression (`3, 5, 7, 10, 14`) to match tech costs/levels (`src/actions/actiontypes.ts`).
- Stat boost action: harden `StatBoostAction.apply` to safely handle absent/empty `levels`, use 1-based `context.level` clamped to the last defined level, and avoid crashes on malformed defs (`src/actions/traitaction/statboostact.ts`).
- Tech tree: wire `stat_might` tech to `actionDefs.AttackStatBoost` so upgrades reference the real action def (`src/techtree/techtreedefs.ts`).

### Testing
- Ran `git diff --check` which succeeded with no whitespace/conflict issues.
- Ran `npx tsc --noEmit` which failed in this environment due to missing project dependencies/type definitions (for example `three` and other ambient libs), so full type-check could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699906405a20832397cf55a969e46c19)