### PR TITLE
Add Fan of Knives skill (multi-projectile) and Knife model wiring

### DIFF
--- a/src/actions/actionregisterinit.ts
+++ b/src/actions/actionregisterinit.ts
@@ -2,6 +2,7 @@ import * as THREE from "three";
 import { ActionRegistry } from "./actionregistry"
 import { StatBoostAction } from "./traitaction/statboostact"
 import { FireballAction } from "./skillactions/fireballact"
+import { KnifeAction } from "./skillactions/knifeact"
 import { MuzzleAction } from "./itemactions/muzzleact";
 import { EventController } from "@Glibs/systems/event/eventctrl";
 import { BulletCasingAct } from "./itemactions/bulletcasingact";
@@ -37,6 +38,8 @@ export function InitActionRegistry(eventCtrl: EventController, scene: THREE.Scen
     ActionRegistry.register("magnetStatBoost", def => new StatBoostAction(def))
     ActionRegistry.register("fireball", def => new FireballAction(eventCtrl, def))
     ActionRegistry.register("projectileFire", def => new FireballAction(eventCtrl, def))
+    ActionRegistry.register("projectileKnife", def => new KnifeAction(eventCtrl, def))
+    ActionRegistry.register("projectileKnifeFan", def => new KnifeAction(eventCtrl, def))
     ActionRegistry.register("meteor", def => new MeteorAction(eventCtrl, scene, def))
     ActionRegistry.register("casing", def => new BulletCasingAct(eventCtrl, scene, def.socket))
     ActionRegistry.register("muzzleFlash", def => {

--- a/src/actions/actiontypes.ts
+++ b/src/actions/actiontypes.ts
@@ -329,6 +329,30 @@ export const actionDefs = {
   // =================================================================
   // Magic
   // =================================================================
+  KnifeThrow: {
+    id: "skill_knife",
+    name: "Knife Throw",
+    trigger: "onCast",
+    type: "projectileKnife",
+    cooldown: 1.2,
+    levels: [
+      { damage: 8, radius: 0.3, speed: 16 },
+      { damage: 12, radius: 0.35, speed: 17 },
+      { damage: 16, radius: 0.4, speed: 18 }
+    ]
+  },
+  FanOfKnives: {
+    id: "skill_fan_of_knives",
+    name: "Fan Of Knives",
+    trigger: "onCast",
+    type: "projectileKnifeFan",
+    cooldown: 2.2,
+    levels: [
+      { damage: 7, radius: 0.3, speed: 15, projectileCount: 5, spreadAngleDeg: 55 },
+      { damage: 10, radius: 0.35, speed: 16, projectileCount: 7, spreadAngleDeg: 70 },
+      { damage: 13, radius: 0.4, speed: 17, projectileCount: 9, spreadAngleDeg: 85 }
+    ]
+  },
   FireBall: {
     id: "fireball",
     name: "Fireball",

--- a/src/actions/skillactions/knifeact.ts
+++ b/src/actions/skillactions/knifeact.ts
@@ -1,0 +1,151 @@
+import * as THREE from "three"
+import IEventController from "@Glibs/interface/ievent"
+import { MonsterId } from "@Glibs/types/monstertypes"
+import { EventTypes } from "@Glibs/types/globaltypes"
+import { ActionContext, IActionComponent, IActionUser } from "@Glibs/types/actiontypes"
+import { ActionDef } from "../actiontypes"
+import { isCooldownReady } from "./cooldownhelper"
+
+export class KnifeAction implements IActionComponent {
+  id = "skill_knife"
+  private cooldown = 1200
+  private lastUsed = 0
+
+  constructor(private eventCtrl: IEventController, private def: ActionDef) {
+    if (typeof def.cooldown === "number") {
+      this.cooldown = def.cooldown * 1000
+    }
+  }
+
+  activate(_target: IActionUser, _context?: ActionContext) {}
+
+  trigger(target: IActionUser, triggerType: "onCast", context?: ActionContext) {
+    if (triggerType !== "onCast") return
+    this.castProjectile(target, context)
+  }
+
+  private castProjectile(target: IActionUser, context?: ActionContext) {
+    const baseSpec = target.baseSpec
+    if (!baseSpec) return
+
+    const now = performance.now()
+    if (!isCooldownReady(this.lastUsed, this.cooldown, target, now)) return
+
+    const caster = this.getCasterObject(target)
+    if (!caster) return
+
+    const level = Math.max(1, context?.level ?? 1)
+    const levelDefs = Array.isArray(this.def.levels) ? this.def.levels : []
+    const levelStat = levelDefs[Math.min(levelDefs.length - 1, level - 1)]
+
+    const damage = typeof levelStat?.damage === "number" ? levelStat.damage : 8
+    const speed = typeof levelStat?.speed === "number" ? levelStat.speed : 16
+    const radius = typeof levelStat?.radius === "number" ? levelStat.radius : 0.3
+    const projectileCount = Math.max(1, Math.floor(typeof levelStat?.projectileCount === "number" ? levelStat.projectileCount : 1))
+    const spreadAngleDeg = typeof levelStat?.spreadAngleDeg === "number" ? Math.max(0, levelStat.spreadAngleDeg) : 0
+
+    const startPos = this.resolveCastOrigin(caster)
+    const attackDir = this.resolveDirection(startPos, caster, context)
+
+    const defaultRange = Math.max(10, radius * 40)
+    const destination = this.asVector3(context?.destination)
+    const range = destination
+      ? Math.max(defaultRange, startPos.distanceTo(destination) + radius * 2)
+      : defaultRange
+
+    const speedScale = Math.max(0.1, speed / 10)
+    const fanDirs = this.buildFanDirections(attackDir, projectileCount, spreadAngleDeg)
+
+    this.lastUsed = now
+    fanDirs.forEach((dir) => {
+      this.eventCtrl.SendEventMessage(EventTypes.Projectile, {
+        id: MonsterId.Knife,
+        ownerSpec: baseSpec,
+        damage,
+        src: startPos.clone(),
+        dir: dir.multiplyScalar(speedScale),
+        range,
+      })
+    })
+  }
+
+  private buildFanDirections(baseDir: THREE.Vector3, projectileCount: number, spreadAngleDeg: number) {
+    if (projectileCount <= 1 || spreadAngleDeg <= 0) return [baseDir.clone().normalize()]
+
+    const axis = new THREE.Vector3(0, 1, 0)
+    const normalizedBase = baseDir.clone().normalize()
+    const step = spreadAngleDeg / (projectileCount - 1)
+    const start = -spreadAngleDeg / 2
+
+    return Array.from({ length: projectileCount }, (_, index) => {
+      const angleDeg = start + step * index
+      const quat = new THREE.Quaternion().setFromAxisAngle(axis, THREE.MathUtils.degToRad(angleDeg))
+      return normalizedBase.clone().applyQuaternion(quat).normalize()
+    })
+  }
+
+  private resolveCastOrigin(caster: THREE.Object3D): THREE.Vector3 {
+    const socketNames = [
+      "muzzlePoint",
+      "hand_r",
+      "RightHand",
+      "mixamorigRightHand",
+      "mixamorig:RightHand",
+      "spine_03",
+      "Head",
+      "mixamorigHead",
+      "mixamorig:Head",
+    ]
+
+    for (const socketName of socketNames) {
+      const socket = caster.getObjectByName(socketName)
+      if (socket) return socket.getWorldPosition(new THREE.Vector3())
+    }
+
+    const fallback = caster.getWorldPosition(new THREE.Vector3())
+    const box = new THREE.Box3().setFromObject(caster)
+    if (!box.isEmpty()) {
+      const height = Math.max(0.4, box.max.y - box.min.y)
+      fallback.y += height * 0.55
+    } else {
+      fallback.y += 1.05
+    }
+    return fallback
+  }
+
+  private getCasterObject(target: IActionUser): THREE.Object3D | undefined {
+    const obj = target.objs
+    if (!obj) return
+    if (obj instanceof THREE.Object3D) return obj
+    return
+  }
+
+  private resolveDirection(startPos: THREE.Vector3, caster: THREE.Object3D, context?: ActionContext) {
+    const destination = this.asVector3(context?.destination)
+    if (destination) {
+      const dirToDestination = destination.clone().sub(startPos)
+      if (dirToDestination.lengthSq() > 0.000001) return dirToDestination.normalize()
+    }
+
+    const fromContext = this.asVector3(context?.direction)
+    if (fromContext && fromContext.lengthSq() > 0.000001) {
+      return fromContext.clone().normalize()
+    }
+
+    const forward = new THREE.Vector3()
+    caster.getWorldDirection(forward)
+    return forward.normalize()
+  }
+
+  private asVector3(value: unknown): THREE.Vector3 | undefined {
+    if (value instanceof THREE.Vector3) return value
+    const candidate = value as { x?: unknown; y?: unknown; z?: unknown } | undefined
+    if (!candidate) return
+    if (typeof candidate.x !== "number" || typeof candidate.y !== "number" || typeof candidate.z !== "number") return
+    return new THREE.Vector3(candidate.x, candidate.y, candidate.z)
+  }
+
+  isAvailable(): boolean {
+    return performance.now() - this.lastUsed >= this.cooldown
+  }
+}

--- a/src/actors/monsters/monstertypes.ts
+++ b/src/actors/monsters/monstertypes.ts
@@ -34,6 +34,7 @@ export class MonsterId {
     public static DefaultBullet = "DefaultBullet"
     public static BulletLine = "BulletL"
     public static Fireball = "fb"
+    public static Knife = "knife"
     public static List = [
         this.Zombie, this.Minotaur, this.Batpig, this.Bilby, this.Birdmon,
         this.Crab, this.Builder, this.Golem, this.BigGolem, this.KittenMonk,

--- a/src/actors/projectile/knifemodel.ts
+++ b/src/actors/projectile/knifemodel.ts
@@ -1,0 +1,85 @@
+import * as THREE from "three";
+import { IAsset } from "@Glibs/interface/iasset";
+import { IProjectileModel } from "./projectile";
+
+export class KnifeModel implements IProjectileModel {
+  private readonly container = new THREE.Group();
+  private loadPromise?: Promise<void>;
+  private loaded = false;
+
+  get Meshs() {
+    return this.container;
+  }
+
+  constructor(private asset?: IAsset) {
+    this.container.visible = false;
+
+    if (!this.asset) {
+      this.attachFallbackMesh();
+      this.loaded = true;
+      return;
+    }
+
+    this.loadPromise = this.loadAssetModel();
+  }
+
+  create(position: THREE.Vector3): void {
+    this.container.position.copy(position);
+    this.container.visible = true;
+
+    if (!this.loaded && !this.loadPromise && this.asset) {
+      this.loadPromise = this.loadAssetModel();
+    }
+  }
+
+  update(position: THREE.Vector3): void {
+    if (!this.container.visible) return;
+    this.container.position.copy(position);
+    this.container.rotateZ(0.45);
+  }
+
+  release(): void {
+    this.container.visible = false;
+  }
+
+  private async loadAssetModel() {
+    if (!this.asset) return;
+
+    try {
+      const model = await this.asset.CloneModel();
+      model.scale.setScalar(0.25);
+      model.rotation.set(Math.PI / 2, 0, 0);
+      model.traverse((node) => {
+        if (!(node instanceof THREE.Mesh)) return;
+        node.castShadow = false;
+        node.receiveShadow = false;
+      });
+
+      this.container.clear();
+      this.container.add(model);
+      this.loaded = true;
+    } catch {
+      this.container.clear();
+      this.attachFallbackMesh();
+      this.loaded = true;
+    }
+  }
+
+  private attachFallbackMesh() {
+    const geometry = new THREE.ConeGeometry(0.08, 0.55, 6);
+    geometry.rotateX(Math.PI / 2);
+
+    const material = new THREE.MeshStandardMaterial({
+      color: 0xcfd6e0,
+      metalness: 0.75,
+      roughness: 0.25,
+      emissive: 0x16202f,
+      emissiveIntensity: 0.35,
+    });
+
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.castShadow = false;
+    mesh.receiveShadow = false;
+    this.container.add(mesh);
+  }
+}

--- a/src/actors/projectile/projectile.ts
+++ b/src/actors/projectile/projectile.ts
@@ -10,6 +10,9 @@ import { BulletLine } from "./bulletline";
 import { StatFactory } from "../battle/statfactory";
 import { BaseSpec } from "../battle/basespec";
 import { FireballModel } from "./fireballmodel";
+import { KnifeModel } from "./knifemodel";
+import { Loader } from "@Glibs/loader/loader";
+import { Char } from "@Glibs/types/assettypes";
 
 export interface IProjectileModel {
     get Meshs(): THREE.Mesh | THREE.Object3D | THREE.Points | THREE.Line | undefined
@@ -46,6 +49,7 @@ export class Projectile implements ILoop {
         private eventCtrl: IEventController,
         private game: THREE.Scene,
         private targetList: THREE.Object3D[],
+        private loader?: Loader,
     ) {
         eventCtrl.SendEventMessage(EventTypes.RegisterLoop, this)
         eventCtrl.RegisterEventListener(EventTypes.Projectile, (opt: ProjectileMsg) => {
@@ -61,6 +65,8 @@ export class Projectile implements ILoop {
                 return new BulletLine()
             case MonsterId.Fireball: // (정의하신 Enum 값으로 맞춰주세요)
                 return new FireballModel()
+            case MonsterId.Knife:
+                return new KnifeModel(this.loader?.GetAssets(Char.KayKitAdvDagger))
             case MonsterId.DefaultBall:
             default:
                 return new DefaultBall(.1)

--- a/src/techtree/techtreedefs.ts
+++ b/src/techtree/techtreedefs.ts
@@ -376,7 +376,7 @@ export const DefaultTechTreeDefs: TechTreeDefBase[] = [
         tags: ["rogue", "projectile"],
         requires: [{ type: "has", id: "class_rogue", minLv: 1 }],
         cost: COST_1,
-        tech: MOCK_TECH
+        tech: actionDefs.KnifeThrow
     },
     {
         id: "skill_fan_of_knives",
@@ -387,7 +387,7 @@ export const DefaultTechTreeDefs: TechTreeDefBase[] = [
         tags: ["rogue", "aoe"],
         requires: [{ type: "has", id: "skill_knife", minLv: 1 }],
         cost: COST_1,
-        tech: MOCK_TECH
+        tech: actionDefs.FanOfKnives
     },
 
     // =================================================================


### PR DESCRIPTION
### Motivation
- Provide a playable "Fan of Knives" skill that emits multiple knife projectiles in a spread while reusing the existing projectile pooling system. 
- Make the knife projectile and asset usage consistent with other projectiles by adding a `KnifeModel` with an asset-based clone and a procedural fallback. 

### Description
- Added a `FanOfKnives` action definition to `src/actions/actiontypes.ts` with level-scaled `projectileCount` and `spreadAngleDeg` alongside `damage/speed/radius`. 
- Implemented `KnifeAction` in `src/actions/skillactions/knifeact.ts` that handles both single-knife and fan behavior by dispatching multiple `EventTypes.Projectile` messages (one per projectile) and computing spread directions via `buildFanDirections`. 
- Registered `projectileKnifeFan` (and `projectileKnife`) in `src/actions/actionregisterinit.ts` so the `FanOfKnives` action type is created at runtime. 
- Added `KnifeModel` in `src/actors/projectile/knifemodel.ts` and added `MonsterId.Knife` in `src/actors/monsters/monstertypes.ts`; `Projectile.GetModel` now provides `KnifeModel` (using loader assets when available and falling back to a cone mesh). 
- Wired the tech tree node `skill_fan_of_knives` to `actionDefs.FanOfKnives` in `src/techtree/techtreedefs.ts` so unlocking the tech grants the castable skill. 

### Testing
- Ran `npm run build` to validate the TypeScript/webpack build, which failed in this environment due to missing `webpack` (`sh: 1: webpack: not found`).
- Confirmed registrations and code edits via local repository commands (file updates staged and committed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69995cb3c1ec83239b9fc55800977fce)