### PR TITLE
Fix ActionType compile error and wire skill-slot cast animations

### DIFF
--- a/src/actions/actiontypes.ts
+++ b/src/actions/actiontypes.ts
@@ -334,6 +334,7 @@ export const actionDefs = {
     name: "Knife Throw",
     trigger: "onCast",
     type: "projectileKnife",
+    castAction: "MagicH1",
     cooldown: 1.2,
     levels: [
       { damage: 8, radius: 0.3, speed: 16 },
@@ -346,6 +347,7 @@ export const actionDefs = {
     name: "Fan Of Knives",
     trigger: "onCast",
     type: "projectileKnifeFan",
+    castAction: "MagicH1",
     cooldown: 2.2,
     levels: [
       { damage: 7, radius: 0.3, speed: 15, projectileCount: 5, spreadAngleDeg: 55 },
@@ -358,6 +360,7 @@ export const actionDefs = {
     name: "Fireball",
     trigger: "onCast",
     type: "projectileFire",
+    castAction: "MagicH1",
     cooldown: 3,
     levels: [
       { damage: 10, radius: 1.0, speed: 10 },
@@ -370,6 +373,7 @@ export const actionDefs = {
     name: "Meteor",
     trigger: "onCast",
     type: "meteor",
+    castAction: "MagicH2",
     cooldown: 7,
     distance: 8,
     fallDuration: 0.65,
@@ -386,6 +390,7 @@ export const actionDefs = {
     name: "Heal",
     trigger: "onCast",
     type: "regen",
+    castAction: "MagicH2",
     cooldown: 5,
     levels: [
       { amount: 20 },

--- a/src/actors/player/player.ts
+++ b/src/actors/player/player.ts
@@ -227,9 +227,9 @@ export class Player extends PhysicsObject {
     clock = new THREE.Clock()
 
     ChangeAction(action: ActionType, speed?: number) {
-        let clip: THREE.AnimationClip | undefined
+        const clip = this.clipMap.get(action)
         this.currentActionType = action
-        this.changeAnimate(this.clipMap.get(action), speed)
+        this.changeAnimate(clip, speed)
         return clip?.duration
     }
 

--- a/src/actors/player/playerctrl.ts
+++ b/src/actors/player/playerctrl.ts
@@ -8,7 +8,7 @@ import { DeckState } from "./states/deckstate";
 import { AppMode, EventTypes } from "@Glibs/types/globaltypes";
 import IEventController, { IKeyCommand, ILoop } from "@Glibs/interface/ievent";
 import { KeyType } from "@Glibs/types/eventtypes";
-import { AttackOption, AttackType, DefaultStatus, PlayMode } from "./playertypes";
+import { ActionType, AttackOption, AttackType, DefaultStatus, PlayMode } from "./playertypes";
 import { IGPhysic } from "@Glibs/interface/igphysics";
 import IInventory, { IItem } from "@Glibs/interface/iinven";
 import { ItemId, itemDefs } from "@Glibs/inventory/items/itemdefs";
@@ -43,6 +43,7 @@ export class PlayerCtrl implements ILoop, IActionUser {
     learnedSkills = new Map<string, LearnedSkillMessage>()
     skillActionSlots: Array<LearnedSkillMessage | undefined> = [undefined, undefined, undefined, undefined]
     skillActions = new Map<string, IActionComponent>()
+    private skillCastAnimTimeout?: NodeJS.Timeout
     private hpRegenAccumulator = 0
     private mpRegenAccumulator = 0
 
@@ -361,6 +362,8 @@ export class PlayerCtrl implements ILoop, IActionUser {
         if (!skill) return false
         if (!this.isActionDef(skill.tech)) return false
 
+        this.playSkillCastMotion(skill.tech)
+
         let action = this.skillActions.get(skill.nodeId)
         if (!action) {
             action = ActionRegistry.create(skill.tech)
@@ -387,6 +390,36 @@ export class PlayerCtrl implements ILoop, IActionUser {
 
         action.activate?.(this, context)
         return true
+    }
+
+    private playSkillCastMotion(tech: ActionDef) {
+        if (this.currentState === this.RollSt || this.currentState === this.DyingSt) return
+
+        const castAction = this.resolveCastActionType(tech)
+        const duration = this.player.ChangeAction(castAction)
+        if (duration == undefined) return
+
+        if (this.skillCastAnimTimeout) clearTimeout(this.skillCastAnimTimeout)
+        this.skillCastAnimTimeout = setTimeout(() => {
+            if (this.player.currentActionType !== castAction) return
+            this.player.ChangeAction(ActionType.Idle)
+            this.skillCastAnimTimeout = undefined
+        }, duration * 1000)
+    }
+
+    private resolveCastActionType(tech: ActionDef): ActionType {
+        if (typeof tech.castAction === "number") {
+            const castAction = tech.castAction as number
+            if (Number.isInteger(castAction) && ActionType[castAction] !== undefined) return castAction
+            return ActionType.MagicH1
+        }
+
+        const castAction = typeof tech.castAction === "string" ? tech.castAction : ""
+        if (castAction === "MagicH2") return ActionType.MagicH2
+        if (castAction === "MagicH1") return ActionType.MagicH1
+
+        if (tech.type === "meteor") return ActionType.MagicH2
+        return ActionType.MagicH1
     }
 
     private isActionDef(value: unknown): value is ActionDef {


### PR DESCRIPTION
### Motivation
- Fix a TypeScript compile error where `ActionType` was missing in `PlayerCtrl` and ensure the skill-slot casting path is robust. 
- Play appropriate cast animations driven by skill metadata so visual feedback matches skill activation. 
- Ensure cast animation returns to `Idle` cleanly and does not interrupt protected player states like rolling or dying.

### Description
- Import `ActionType` into `src/actors/player/playerctrl.ts` and add `skillCastAnimTimeout`, `playSkillCastMotion()` and `resolveCastActionType()` to select and play cast animations before activating a skill. 
- Call `playSkillCastMotion()` from `castLearnedSkill()` so slot-click and keyboard-triggered casts play animation then trigger the action. 
- Modify `src/actors/player/player.ts` `ChangeAction()` to return the selected animation clip duration (and minor local refactor to use a `const clip`), enabling accurate timeout-based return-to-idle. 
- Add optional `castAction` metadata to several action definitions in `src/actions/actiontypes.ts` (`KnifeThrow`, `FanOfKnives`, `FireBall`, `Meteor`, `Heal`) so skills can specify `MagicH1`/`MagicH2` cast motions.

### Testing
- Verified source wiring and symbols via code inspection and searches for `playSkillCastMotion`, `resolveCastActionType`, and `castAction` to confirm hooks are present and `PlayerCtrl` listens to `EventTypes.SkillSlotCast` and keyboard `Action5~Action8` paths. 
- Ran file inspections and snippets with `sed`, `nl` and `rg` to review modified regions and ensure no obvious type mismatches were left. 
- Attempted `npm install` to build, but full build could not be executed due to registry permission error (`403` for `@tensorflow/tfjs-node`), so no full compilation or automated test run was performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac5e1d7708323a884a0e89f310dff)