### PR TITLE
Fix ranged weapon equip/display and enable manual-aim camera for melee

### DIFF
--- a/src/actors/player/player.ts
+++ b/src/actors/player/player.ts
@@ -85,19 +85,20 @@ export class Player extends PhysicsObject {
         delete this.bindMesh[bind]
     }
     ReloadBindingItem(item: IItem) {
-        if(item.Bind == undefined) throw new Error("item bind is undefined")
+        const bind = item.ItemType === "rangeattack" ? Bind.Weapon_Ranged : item.Bind
+        if(bind == undefined) throw new Error("item bind is undefined")
 
-        const rightId = this.asset.GetBodyMeshId(item.Bind)
+        const rightId = this.asset.GetBodyMeshId(bind)
         if (rightId == undefined) return
 
         const mesh = this.meshs.getObjectByName(rightId)
         if (!mesh) return
-        const prev = this.bindMesh[item.Bind]
+        const prev = this.bindMesh[bind]
 
         if (prev) {
             //mesh.remove(prev)
             prev.visible = false
-            delete this.bindMesh[item.Bind]
+            delete this.bindMesh[bind]
         }
 
         if (item && item.Mesh != undefined) {
@@ -107,7 +108,7 @@ export class Player extends PhysicsObject {
             } else {
                 mesh.add(item.Mesh)
             }
-            this.bindMesh[item.Bind] = item.Mesh
+            this.bindMesh[bind] = item.Mesh
         }
     }
 

--- a/src/actors/player/playerctrl.ts
+++ b/src/actors/player/playerctrl.ts
@@ -180,8 +180,9 @@ export class PlayerCtrl implements ILoop, IActionUser {
         eventCtrl.RegisterEventListener(EventTypes.Equipment, (id: ItemId) => {
             const slot = this.inventory.GetItemSlot(id)
             if (slot == undefined) throw new Error("item is undefined")
-            if (slot.item.Bind) {
-                const prevItem = this.baseSpec.GetBindItem(slot.item.Bind);
+            const targetSlot = slot.item.ItemType === "rangeattack" ? Bind.Weapon_Ranged : slot.item.Bind
+            if (targetSlot) {
+                const prevItem = this.baseSpec.GetBindItem(targetSlot);
                 if (prevItem) (prevItem as Item).deactivate()
             }
             this.baseSpec.Equip(slot.item);

--- a/src/actors/player/states/combomeleeattackst.ts
+++ b/src/actors/player/states/combomeleeattackst.ts
@@ -13,6 +13,7 @@ import { Item } from "@Glibs/inventory/items/item";
 import { AttackState } from "./attackstate";
 import { KeyType } from "@Glibs/types/eventtypes";
 import { GlobalEffectType } from "@Glibs/types/effecttypes";
+import { CameraMode } from "@Glibs/systems/camera/cameratypes";
 
 /* -------------------------------------------------------------------------- */
 /* Types                                                                      */
@@ -543,7 +544,7 @@ export class ComboMeleeState extends AttackState implements IPlayerAction {
         this.hitTimerFired = false;
 
         // 무기 세팅/오토에임
-        const handItem = this.playerCtrl.baseSpec.GetBindItem(Bind.Hands_R);
+        const handItem = this.playerCtrl.baseSpec.GetMeleeItem();
         if (handItem) {
             // 아이템 Action.activate는 장착 시점(PlayerCtrl.Equipment)에서 1회 호출됨
             // 공격 시작/콤보 스텝에서는 onUse 트리거만 발행
@@ -552,7 +553,15 @@ export class ComboMeleeState extends AttackState implements IPlayerAction {
                 this.eventCtrl.SendEventMessage(EventTypes.RegisterSound, (handItem as any).Mesh, (handItem as any).Sound);
             }
             this.autoAttack = handItem.AutoAttack;
-            if (this.autoAttack) this.autoDirection();
+            if (this.autoAttack) {
+                this.eventCtrl.SendEventMessage(EventTypes.AimOverlay, false)
+                this.eventCtrl.SendEventMessage(EventTypes.CameraMode, CameraMode.ThirdFollowPerson)
+                this.autoDirection();
+            } else {
+                this.eventCtrl.SendEventMessage(EventTypes.CameraMode, CameraMode.AimThirdPerson)
+                this.eventCtrl.SendEventMessage(EventTypes.AimOverlay, true)
+                this.detectEnermy = true
+            }
         }
 
         // 예약 스케줄
@@ -695,6 +704,8 @@ export class ComboMeleeState extends AttackState implements IPlayerAction {
         this.comboWindowOpen = false;
         this.nextStepQueued = false;
         this.hitstopLeft = 0;
+        this.eventCtrl.SendEventMessage(EventTypes.AimOverlay, false)
+        this.eventCtrl.SendEventMessage(EventTypes.CameraMode, CameraMode.ThirdFollowPerson)
         super.Uninit();
     }
 }

--- a/src/systems/camera/camera.ts
+++ b/src/systems/camera/camera.ts
@@ -91,7 +91,7 @@ export class Camera extends THREE.PerspectiveCamera implements IViewer, ILoop {
             new THREE.Vector3(10, 10, 0),
             new THREE.Vector3(0, 5, -10)
         ]));
-        this.strategies.set(CameraMode.AimThirdPerson, new AimThirdPersonCameraStrategy());
+        this.strategies.set(CameraMode.AimThirdPerson, new AimThirdPersonCameraStrategy(this.controls, this));
         // 여기에 다른 전략도 추가하세요
         this.strategy = this.strategies.get(this.mode)!;
     }


### PR DESCRIPTION
### Motivation
- Ranged weapons equipped as `rangeattack` were not consistently attached to the `weapon_ranged` slot, so the soul dialog slot and character render could disagree and the ranged item would not appear.
- The system supports having both melee and ranged items equipped and should show the correct item depending on attack type.
- When performing manual (non-auto) melee attacks the camera should allow the player to move the view to select targets (current aim mode blocked viewpoint movement).

### Description
- Use `Bind.Weapon_Ranged` for items with `ItemType === "rangeattack"` when equipping so the deactivation/replace flow targets the correct bind slot (`src/actors/player/playerctrl.ts`).
- Make player mesh binding/reload respect ranged items by resolving the bind to `Bind.Weapon_Ranged` for `rangeattack` items (`src/actors/player/player.ts`).
- Prefer `GetMeleeItem()` in combo/melee code so melee attacks use the correct (melee) item when both melee and ranged items are present, and add parity for manual-melee aiming (switch camera to aim mode and enable aim overlay) (`src/actors/player/states/combomeleeattackst.ts`).
- Ensure exiting melee combo restores camera mode and hides the aim overlay (`src/actors/player/states/combomeleeattackst.ts`).
- Replace the aim camera strategy with an OrbitControls-aware variant so the player can rotate the view while in `AimThirdPerson`, with constrained polar angles and disabled pan/zoom; inject `OrbitControls` into the aim strategy (`src/systems/camera/aimview.ts`, `src/systems/camera/camera.ts`).

### Testing
- Attempted a project build with `npm run build`, but the environment lacks `webpack` so the build could not be run here (`sh: 1: webpack: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b82e74eb083239c3166a761c2d7d4)