### PR TITLE
Fix aim camera auto-rotation and show ranged items in Soul dialog

### DIFF
--- a/src/systems/camera/aimview.ts
+++ b/src/systems/camera/aimview.ts
@@ -16,9 +16,11 @@ export default class AimThirdPersonCameraStrategy implements ICameraStrategy {
         private controls: OrbitControls,
         private camera: THREE.Camera,
     ) {
+        this.controls.autoRotate = false
         this.controls.enableRotate = true
         this.controls.enablePan = false
         this.controls.enableZoom = false
+        this.controls.enableDamping = false
         this.controls.minPolarAngle = 0.25
         this.controls.maxPolarAngle = Math.PI / 2 - 0.05
     }

--- a/src/ux/dialog/souldialog/views/characterview.ts
+++ b/src/ux/dialog/souldialog/views/characterview.ts
@@ -22,6 +22,13 @@ export type EquipSlot =
     | 'ring1' | 'ring2' | 'amulet';
 
 const SLOTS: EquipSlot[] = ['head', 'chest', 'hands', 'legs', 'weapon', 'weapon_ranged', 'offhand', 'ring1', 'ring2', 'amulet'];
+const SLOT_ALIASES: Partial<Record<EquipSlot, string[]>> = {
+    weapon: ['handr'],
+    offhand: ['handl'],
+    ring1: ['fngerl'],
+    ring2: ['fngerr'],
+    amulet: ['amu'],
+};
 
 export interface IStatValue {
     total: number; // 최종 수치
@@ -307,7 +314,7 @@ export class CharacterView implements IDialogView<Props> {
         const grid = createEl(doc, 'div'); grid.className = 'gnx-equip-grid';
 
         SLOTS.forEach((slot) => {
-            const item = this.props.equip?.[slot];
+            const item = this.resolveEquipItem(slot);
             const cell = this.createEquipSlot(doc, slot, item);
             grid.appendChild(cell);
         });
@@ -319,6 +326,18 @@ export class CharacterView implements IDialogView<Props> {
         this.shell.body.appendChild(wrap);
 
         this.ctx.render.setActions(this.shell, [{ id: 'close', label: '닫기', onClick: () => this.ctx.manager.close() }]);
+    }
+
+    private resolveEquipItem(slot: EquipSlot): IItem | null | undefined {
+        const direct = this.props.equip?.[slot];
+        if (direct) return direct;
+
+        const aliases = SLOT_ALIASES[slot] ?? [];
+        for (const key of aliases) {
+            const aliasItem = (this.props.equip as Record<string, IItem | null | undefined> | undefined)?.[key];
+            if (aliasItem) return aliasItem;
+        }
+        return direct;
     }
 
     private mountRenderer() {

--- a/src/ux/dialog/souldialog/views/inventoryview.ts
+++ b/src/ux/dialog/souldialog/views/inventoryview.ts
@@ -10,6 +10,11 @@ import { TooltipComponent } from '../core/tooltip';
 
 type Slot = 'head' | 'chest' | 'hands' | 'legs' | 'weapon' | 'weapon_ranged' | 'offhand';
 
+const SLOT_ALIASES: Partial<Record<Slot, string[]>> = {
+  weapon: ['handr'],
+  offhand: ['handl'],
+};
+
 const CSS_INV = css`
   .gnx-invwrap{ display:grid; gap:14px; grid-template-columns: 360px 1fr; align-items:start; }
   @media (max-width:1000px){ .gnx-invwrap{ grid-template-columns: 1fr; } }
@@ -163,7 +168,7 @@ export class InventoryView implements IDialogView<Props> {
     this.eqSlots.forEach(s => {
       const slot = createEl(doc,'div'); slot.className='gnx-e-slot'; (slot as any).dataset.slot=s;
       const cap = createEl(doc,'div'); cap.className='cap'; cap.textContent = s;
-      const it = this.props.equip?.[s] ?? null;
+      const it = this.resolveEquipItem(s) ?? null;
       slot.appendChild(cap);
       
       const iconWrap = createEl(doc, 'div');
@@ -312,6 +317,18 @@ export class InventoryView implements IDialogView<Props> {
     right.appendChild(grid);
 
     this.updateActions();
+  }
+
+  private resolveEquipItem(slot: Slot): IItem | null | undefined {
+    const direct = this.props.equip?.[slot];
+    if (direct) return direct;
+
+    const aliases = SLOT_ALIASES[slot] ?? [];
+    for (const key of aliases) {
+      const aliasItem = (this.props.equip as Record<string, IItem | null | undefined> | undefined)?.[key];
+      if (aliasItem) return aliasItem;
+    }
+    return direct;
   }
 
   /* Helpers */


### PR DESCRIPTION
### Motivation
- The aim camera was continuously rotating and preventing manual targeting input, and equipped ranged items were not visible in the Soul dialog because UI slot keys differed from runtime bind keys.

### Description
- Disable `OrbitControls` auto-rotation and damping in aim camera strategy by setting `autoRotate = false` and `enableDamping = false` in `AimThirdPersonCameraStrategy` (`src/systems/camera/aimview.ts`).
- Add slot alias mapping and resolution helper in Soul dialog `CharacterView` so UI slots (`weapon`, `offhand`, etc.) can display items stored under bind keys like `handr`/`handl` (`src/ux/dialog/souldialog/views/characterview.ts`).
- Apply the same alias-based resolution to the Inventory view equipment panel so equipped melee/ranged items are shown correctly (`src/ux/dialog/souldialog/views/inventoryview.ts`).

### Testing
- Attempted `npm run build` but `webpack` binary was not available so build failed with `webpack: not found` (local environment limitation).
- Attempted `npm ci` to install dependencies but `npm ci` failed due to registry policy returning `403 Forbidden` for `@tensorflow/tfjs-node` in this environment.
- Code changes compiled locally were not validated by a full build due to the above environment constraints, but affected files were updated and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b8714ee448323a7ea73035bea67c2)