### PR TITLE
Separate manual aim firing into AimRangeAttackState and simplify RangeAttackState

### DIFF
--- a/src/actors/player/playerctrl.ts
+++ b/src/actors/player/playerctrl.ts
@@ -19,6 +19,8 @@ import { Item } from "@Glibs/inventory/items/item";
 import { Buff } from "@Glibs/magical/buff/buff";
 import { MeleeAttackState } from "./states/meleeattackst";
 import { RangeAttackState } from "./states/rangeattackst";
+import { RangeAimState } from "./states/rangeaimst";
+import { AimRangeAttackState } from "./states/aimrangeattackst";
 import { ComboMeleeState } from "./states/combomeleeattackst";
 import { EventActionState, EventIdleState } from "./states/eventstate";
 import { Bind } from "@Glibs/types/assettypes";
@@ -59,6 +61,8 @@ export class PlayerCtrl implements ILoop, IActionUser {
     MeleeAttackSt: MeleeAttackState
     ComboMeleeSt: ComboMeleeState
     RangeAttackSt: RangeAttackState
+    RangeAimSt: RangeAimState
+    AimRangeAttackSt: AimRangeAttackState
     MagicH1St: MagicH1State
     MagicH2St: MagicH2State
     AttackIdleSt: AttackIdleState
@@ -108,6 +112,8 @@ export class PlayerCtrl implements ILoop, IActionUser {
         this.MeleeAttackSt = new MeleeAttackState(this, this.player, this.gphysic, this.eventCtrl, this.baseSpec)
         this.ComboMeleeSt = new ComboMeleeState(this, this.player, this.gphysic, this.eventCtrl, this.baseSpec)
         this.RangeAttackSt = new RangeAttackState(this, this.player, this.gphysic, this.eventCtrl, this.baseSpec)
+        this.RangeAimSt = new RangeAimState(this, this.player, this.gphysic, this.eventCtrl, this.baseSpec)
+        this.AimRangeAttackSt = new AimRangeAttackState(this, this.player, this.gphysic, this.eventCtrl, this.baseSpec)
         this.MagicH1St = new MagicH1State(this, this.player, this.gphysic, this.baseSpec)
         this.MagicH2St = new MagicH2State(this, this.player, this.gphysic, this.baseSpec)
         this.AttackIdleSt = new AttackIdleState(this, this.player, this.gphysic, this.baseSpec)

--- a/src/actors/player/states/playerstate.ts
+++ b/src/actors/player/states/playerstate.ts
@@ -56,8 +56,10 @@ export class State {
             if (this.playerCtrl.mode == AppMode.Play) {
                 const meleeItem = this.playerCtrl.baseSpec.GetMeleeItem()
                 const rangedItem = this.playerCtrl.baseSpec.GetRangedItem()
-                const state = (!rangedItem && (meleeItem?.ItemType == "meleeattack" || !meleeItem))
-                    ? this.playerCtrl.ComboMeleeSt : this.playerCtrl.RangeAttackSt
+                const useMeleeState = (!rangedItem && (meleeItem?.ItemType == "meleeattack" || !meleeItem))
+                const state = useMeleeState
+                    ? this.playerCtrl.ComboMeleeSt
+                    : (rangedItem?.AutoAttack ? this.playerCtrl.RangeAttackSt : this.playerCtrl.RangeAimSt)
                 state.Init()
                 return state
             } else if (this.playerCtrl.mode == AppMode.Weapon) {
@@ -121,8 +123,10 @@ export class State {
             if (attackRange > dis) {
                 const meleeItem = this.playerCtrl.baseSpec.GetMeleeItem()
                 const rangedItem = this.playerCtrl.baseSpec.GetRangedItem()
-                const state = (!rangedItem && (meleeItem?.ItemType == "meleeattack" || !meleeItem))
-                    ? this.playerCtrl.ComboMeleeSt : this.playerCtrl.RangeAttackSt
+                const useMeleeState = (!rangedItem && (meleeItem?.ItemType == "meleeattack" || !meleeItem))
+                const state = useMeleeState
+                    ? this.playerCtrl.ComboMeleeSt
+                    : (rangedItem?.AutoAttack ? this.playerCtrl.RangeAttackSt : this.playerCtrl.RangeAimSt)
                 state.Init()
                 return state
             }

--- a/src/actors/player/states/rangeaimst.ts
+++ b/src/actors/player/states/rangeaimst.ts
@@ -1,0 +1,102 @@
+import * as THREE from "three";
+import { IPlayerAction, State } from "./playerstate";
+import { Player } from "../player";
+import { BaseSpec } from "../../battle/basespec";
+import { IGPhysic } from "@Glibs/interface/igphysics";
+import IEventController from "@Glibs/interface/ievent";
+import { EventTypes } from "@Glibs/types/globaltypes";
+import { CameraMode } from "@Glibs/systems/camera/cameratypes";
+import { PlayerCtrl } from "../playerctrl";
+import { ActionType } from "../playertypes";
+import { Item } from "@Glibs/inventory/items/item";
+import { KeyType } from "@Glibs/types/eventtypes";
+import { AttackItemType } from "@Glibs/types/inventypes";
+
+export class RangeAimState extends State implements IPlayerAction {
+    private waitReleaseBeforeFire = false
+    private keepAimCameraOnExit = false
+
+    constructor(
+        playerCtrl: PlayerCtrl,
+        player: Player,
+        gphysic: IGPhysic,
+        private eventCtrl: IEventController,
+        baseSpec: BaseSpec,
+    ) {
+        super(playerCtrl, player, gphysic, baseSpec)
+    }
+
+    Init(): void {
+        const handItem = this.playerCtrl.baseSpec.GetRangedItem()
+        if (!handItem) {
+            this.playerCtrl.currentIdleState.Init()
+            return
+        }
+        if (handItem.AutoAttack) {
+            this.playerCtrl.RangeAttackSt.Init()
+            return
+        }
+
+        this.keepAimCameraOnExit = false
+        this.player.ChangeAction(this.getAnimationForItem(handItem), this.baseSpec.AttackSpeed)
+        this.eventCtrl.SendEventMessage(EventTypes.CameraMode, CameraMode.AimThirdPerson)
+        this.eventCtrl.SendEventMessage(EventTypes.AimOverlay, true)
+        this.player.createDashedCircle(this.baseSpec.AttackRange)
+        this.waitReleaseBeforeFire = this.playerCtrl.KeyState[KeyType.Action1] === true
+
+        ;(handItem as Item).activate()
+        this.eventCtrl.SendEventMessage(EventTypes.RegisterSound, handItem.Mesh, handItem.Sound)
+    }
+
+    Uninit(): void {
+        if (!this.keepAimCameraOnExit) {
+            this.eventCtrl.SendEventMessage(EventTypes.AimOverlay, false)
+            this.eventCtrl.SendEventMessage(EventTypes.CameraMode, CameraMode.ThirdFollowPerson)
+        }
+        this.player.releaseDashsedCircle()
+    }
+
+    Update(): IPlayerAction {
+        const d = this.DefaultCheck({ attack: false })
+        if (d != undefined) {
+            this.Uninit()
+            return d
+        }
+
+        const camForward = new THREE.Vector3();
+        this.playerCtrl.camera.getWorldDirection(camForward);
+        camForward.y = 0;
+        camForward.normalize();
+        this.player.Meshs.lookAt(
+            this.player.Pos.x + camForward.x,
+            this.player.Pos.y,
+            this.player.Pos.z + camForward.z
+        );
+
+        const firePressed = this.playerCtrl.KeyState[KeyType.Action1] === true
+        if (this.waitReleaseBeforeFire) {
+            if (!firePressed) this.waitReleaseBeforeFire = false
+            return this
+        }
+
+        if (firePressed) {
+            this.keepAimCameraOnExit = true
+            this.Uninit()
+            this.playerCtrl.AimRangeAttackSt.Init()
+            return this.playerCtrl.AimRangeAttackSt
+        }
+
+        return this
+    }
+
+    private getAnimationForItem(item: any): ActionType {
+        switch (item.AttackType) {
+            case AttackItemType.OneHandGun:
+                return ActionType.OneHandGun
+            case AttackItemType.TwoHandGun:
+                return ActionType.TwoHandGun
+            default:
+                return ActionType.Punch
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent camera/overlay toggles and mixed responsibilities by isolating manual-aim firing into a dedicated state instead of overloading the auto-attack state.
- Make the aiming UX explicit: `RangeAimState` handles camera/overlay and waits for deliberate fire input, and a short-lived firing state performs the shot and returns to aim.

### Description
- Added `AimRangeAttackState` (`src/actors/player/states/aimrangeattackst.ts`) which performs a single manual ranged shot and transitions back to `RangeAimState` after firing.
- Updated `RangeAimState` (`src/actors/player/states/rangeaimst.ts`) to only manage aiming UI/camera, wait for `Action1` release when necessary, set `keepAimCameraOnExit`, and transition to `AimRangeAttackSt` on explicit fire.
- Simplified `RangeAttackState` (`src/actors/player/states/rangeattackst.ts`) by removing manual-aim branching and related fields so it now represents auto-ranged attack behavior only.
- Registered the new state in `PlayerCtrl` (`src/actors/player/playerctrl.ts`) by creating `AimRangeAttackSt` and wiring transitions; adjusted state selection logic in `playerstate.ts` to choose `RangeAimSt` for manual ranged weapons.

### Testing
- Ran `npm run build` in this environment and the build failed due to missing local toolchain (`webpack: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bafa1ddd08323b2150c8e93ad2599)