### PR TITLE
Allow OrbitControls movement while aiming (fix camera lock in RangeAimState)

### DIFF
--- a/src/systems/camera/aimview.ts
+++ b/src/systems/camera/aimview.ts
@@ -6,6 +6,7 @@ import { IPhysicsObject } from "@Glibs/interface/iobject";
 export default class AimThirdPersonCameraStrategy implements ICameraStrategy {
     private purePosition = new THREE.Vector3();
     private pureQuaternion = new THREE.Quaternion();
+    private isOrbiting = false;
 
     private readonly shoulderOffset = new THREE.Vector3(0.45, 1.6, 0);
     private readonly backDistance = 1.2;
@@ -28,12 +29,12 @@ export default class AimThirdPersonCameraStrategy implements ICameraStrategy {
         this.controls.enabled = true;
         this.controls.autoRotate = false;
         this.controls.enableRotate = true;
-        this.controls.enablePan = false;
-        this.controls.enableZoom = false; 
+        this.controls.enablePan = true;
+        this.controls.enableZoom = true;
         this.controls.enableDamping = false;
         
-        this.controls.minDistance = this.backDistance;
-        this.controls.maxDistance = this.backDistance;
+        this.controls.minDistance = 0.8;
+        this.controls.maxDistance = 8;
         
         this.controls.minPolarAngle = 0.1;
         this.controls.maxPolarAngle = Math.PI - 0.1;
@@ -41,10 +42,12 @@ export default class AimThirdPersonCameraStrategy implements ICameraStrategy {
 
     orbitStart(): void {
         this.controls.enabled = true;
+        this.isOrbiting = true;
     }
 
     orbitEnd(): void {
         this.controls.enabled = true;
+        this.isOrbiting = false;
     }
 
     update(camera: THREE.Camera, player?: IPhysicsObject): void {
@@ -64,7 +67,9 @@ export default class AimThirdPersonCameraStrategy implements ICameraStrategy {
         }
 
         // 2. Update OrbitControls using the pure camera
-        this.controls.target.copy(target);
+        if (!this.isOrbiting) {
+            this.controls.target.copy(target);
+        }
         this.controls.update();
 
         // 3. Save new pure state


### PR DESCRIPTION
### Motivation
- Range aiming felt locked because the aim camera strategy forced a fixed orbit distance and continuously overwrote `OrbitControls.target`, preventing the player from dragging/rotating to search targets.
- The change aims to let players scan for targets while in `RangeAimState` by allowing normal OrbitControls interactions during manual orbit.

### Description
- Added an `isOrbiting` flag to `AimThirdPersonCameraStrategy` to detect user drag via `orbitStart`/`orbitEnd` and avoid overwriting `controls.target` while the user is orbiting (`src/systems/camera/aimview.ts`).
- Relaxed aim-mode control limits by enabling pan/zoom and changing fixed `minDistance/maxDistance` to a range (`minDistance = 0.8`, `maxDistance = 8`).
- Left the previous pure-state save/restore logic intact while switching to conditional target updates so automatic camera placement still works when not user-orbiting.

### Testing
- Attempted to run the project build with `npm run build`, but the command failed in this environment because `webpack` is not available in PATH (`sh: 1: webpack: not found`).
- No other automated tests were present or executed in the repo during this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bd74629148323ba0657acd529a261)