### PR TITLE
Stabilize follow camera when player backpedals toward camera

### DIFF
--- a/src/systems/camera/followcam.ts
+++ b/src/systems/camera/followcam.ts
@@ -7,8 +7,13 @@ export default class ThirdPersonFollowCameraStrategy implements ICameraStrategy 
     private isFreeView = false;
     private dragTimer: ReturnType<typeof setTimeout> | null = null;
     private readonly dragTimeoutMs = 2000;
-    
+    private readonly backwardIgnoreThreshold = -0.15;
+    private readonly cameraApproachIgnoreThreshold = 0.35;
+    private readonly safeMinDistancePadding = 0.4;
+
     private prevPlayerPos = new THREE.Vector3();
+    private stableOffset = new THREE.Vector3();
+    private hasStableOffset = false;
     private raycaster = new THREE.Raycaster();
 
     constructor(
@@ -56,38 +61,79 @@ export default class ThirdPersonFollowCameraStrategy implements ICameraStrategy 
     update(camera: THREE.Camera, player?: IPhysicsObject) {
         if (!player) return;
 
-        const isMoving = player.CenterPos.distanceToSquared(this.prevPlayerPos) > 0.0001;
+        const moveDelta = new THREE.Vector3().subVectors(player.CenterPos, this.prevPlayerPos);
+        const isMoving = moveDelta.lengthSq() > 0.0001;
         this.prevPlayerPos.copy(player.CenterPos);
 
         // Sync Controls Target
         this.controls.target.copy(player.CenterPos);
 
-        // Auto-Follow Logic: Manipulate OrbitControls Limits to force rotation
-        if (!this.isFreeView && isMoving) {
-            const offset = new THREE.Vector3().subVectors(camera.position, player.CenterPos);
-            const playerForward = new THREE.Vector3(0, 0, 1).applyQuaternion(player.Meshs.quaternion);
-            const offsetDir = offset.clone().normalize();
-            
-            const dot = playerForward.dot(offsetDir);
-            
-            // Only rotate if player is facing away (Zelda style)
-            if (dot < -0.1) {
-                const backDir = playerForward.clone().multiplyScalar(-1);
-                const targetTheta = Math.atan2(backDir.x, backDir.z);
-                const currentTheta = this.controls.getAzimuthalAngle();
-                
-                let diff = targetTheta - currentTheta;
-                while (diff > Math.PI) diff -= 2 * Math.PI;
-                while (diff < -Math.PI) diff += 2 * Math.PI;
-                
-                const newTheta = currentTheta + diff * 0.04; // Smooth turn speed
-                
-                this.controls.minAzimuthAngle = newTheta;
-                this.controls.maxAzimuthAngle = newTheta;
-            }
+        const offset = new THREE.Vector3().subVectors(camera.position, player.CenterPos);
+        if (!this.hasStableOffset && offset.lengthSq() > 0.0001) {
+            this.stableOffset.copy(offset);
+            this.hasStableOffset = true;
         }
 
-        this.controls.update();
+        // Auto-Follow Logic: Manipulate OrbitControls Limits to force rotation
+        if (!this.isFreeView && isMoving) {
+            const playerForward = new THREE.Vector3(0, 0, 1).applyQuaternion(player.Meshs.quaternion);
+            const moveDir = moveDelta.clone().normalize();
+            const offsetDir = offset.clone().normalize();
+            const moveForwardness = moveDir.dot(playerForward);
+            const cameraApproachness = moveDir.dot(offsetDir);
+
+            // When moving backwards or directly toward the camera, keep heading stable
+            // to prevent unwanted yaw corrections.
+            const shouldIgnoreAutoFollow =
+                moveForwardness < this.backwardIgnoreThreshold ||
+                cameraApproachness > this.cameraApproachIgnoreThreshold;
+
+            if (shouldIgnoreAutoFollow) {
+                const isCameraInFrontHemisphere = playerForward.dot(offsetDir) > 0;
+                const minSafeDistance = this.controls.minDistance + this.safeMinDistancePadding;
+                const isTooClose = offset.length() < minSafeDistance;
+
+                if (this.hasStableOffset && (isCameraInFrontHemisphere || isTooClose)) {
+                    camera.position.copy(player.CenterPos).add(this.stableOffset);
+                }
+
+                this.controls.update();
+            } else {
+                const dot = playerForward.dot(offsetDir);
+
+                // Only rotate if player is facing away (Zelda style)
+                if (dot < -0.1) {
+                    const backDir = playerForward.clone().multiplyScalar(-1);
+                    const targetTheta = Math.atan2(backDir.x, backDir.z);
+                    const currentTheta = this.controls.getAzimuthalAngle();
+
+                    let diff = targetTheta - currentTheta;
+                    while (diff > Math.PI) diff -= 2 * Math.PI;
+                    while (diff < -Math.PI) diff += 2 * Math.PI;
+
+                    const newTheta = currentTheta + diff * 0.04; // Smooth turn speed
+
+                    this.controls.minAzimuthAngle = newTheta;
+                    this.controls.maxAzimuthAngle = newTheta;
+                }
+
+                this.controls.update();
+
+                const updatedOffset = new THREE.Vector3().subVectors(camera.position, player.CenterPos);
+                if (updatedOffset.lengthSq() > 0.0001) {
+                    this.stableOffset.copy(updatedOffset);
+                    this.hasStableOffset = true;
+                }
+            }
+        } else {
+            this.controls.update();
+
+            const updatedOffset = new THREE.Vector3().subVectors(camera.position, player.CenterPos);
+            if (updatedOffset.lengthSq() > 0.0001) {
+                this.stableOffset.copy(updatedOffset);
+                this.hasStableOffset = true;
+            }
+        }
 
         // Release Azimuth Lock immediately so user can rotate next frame if they want
         this.controls.minAzimuthAngle = -Infinity;


### PR DESCRIPTION
### Motivation
- Prevent the follow-camera from climbing above and spinning with the player when the player backpedals or moves directly toward the camera by suppressing forced azimuth corrections in those unsafe cases.
- Preserve the Zelda-style auto-follow behavior when the player is moving forward and the camera is behind the player.
- Avoid sudden camera collapse/flip when the camera becomes too close to the player by restoring a last-known-good offset.

### Description
- Add a stable camera offset cache (`stableOffset`) and flag (`hasStableOffset`) plus a `safeMinDistancePadding` field to retain and reuse a safe camera offset when needed.
- Replace position-only motion checks with per-frame `moveDelta`/`moveDir` and compute `moveForwardness` and `cameraApproachness` to detect backward motion or direct camera-approach; compute `shouldIgnoreAutoFollow` from those values.
- When `shouldIgnoreAutoFollow` is true and the camera is in the player’s front hemisphere or is too close, restore camera position from `stableOffset` and skip azimuth forcing; otherwise keep the existing azimuth-locking (smooth Zelda-style follow) and update `stableOffset` during normal operation.
- Leave collision/clamping (`raycaster` checks) and immediate azimuth lock release behavior unchanged to keep user rotation responsive.

### Testing
- Ran `npm run build`, which failed in this environment due to missing `webpack` (`sh: 1: webpack: not found`) so no artifact build could be validated automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c1d8c9ba88323bb7b0f5a92099072)