### PR TITLE
Fix TPS aim parallax by shooting from muzzle toward reticle ray hit

### DIFF
--- a/src/actors/player/states/aimrangeattackst.ts
+++ b/src/actors/player/states/aimrangeattackst.ts
@@ -43,9 +43,14 @@ export class AimRangeAttackState extends AttackState implements IPlayerAction {
     }
 
     rangedAttack(itemInfo: IItem) {
-        const startPos = new THREE.Vector3()
-        this.player.Meshs.getWorldDirection(this.attackDir)
-        this.player.GetMuzzlePosition(startPos);
+        const gunPos = new THREE.Vector3()
+        this.player.GetMuzzlePosition(gunPos)
+
+        // 화면 중앙 조준점이 가리키는 월드 좌표를 얻는다.
+        const targetPos = this.getReticleWorldTarget(this.attackDist)
+        // 실제 총구 기준 발사 벡터를 계산해 시차(parallax)를 제거한다.
+        const shootDir = this.computeShootDirectionFromGun(gunPos, targetPos)
+        this.attackDir.copy(shootDir)
 
         (itemInfo as Item).trigger("onFire", { direction: this.attackDir })
 
@@ -53,7 +58,7 @@ export class AimRangeAttackState extends AttackState implements IPlayerAction {
             id: MonsterId.BulletLine,
             ownerSpec: this.baseSpec,
             damage: this.baseSpec.Damage,
-            src: startPos,
+            src: gunPos,
             dir: this.attackDir,
             range: this.attackDist
         })


### PR DESCRIPTION
### Motivation
- Fix over-the-shoulder parallax where the on-screen reticle does not match actual bullet impact by computing the world point the reticle is aiming at and firing from the muzzle toward that point.

### Description
- Added reusable aiming helpers to `AttackState`: `getReticleWorldTarget(maxDistance)`, `computeShootDirectionFromGun(gunPos, targetPos)`, and `isPlayerOwnedObject(obj)`, plus a `FAR_AIM_DISTANCE` fallback constant to handle no-hit cases.
- `getReticleWorldTarget` performs a `THREE.Raycaster` from screen center (NDC `0,0`) using the active camera, checks world objects and combat targets, ignores hits on the player, returns the hit point or a far point along camera forward when nothing is hit.
- `computeShootDirectionFromGun` returns the normalized direction vector `normalize(P_target - P_gun)` for muzzle-based firing.
- Updated `AimRangeAttackState.rangedAttack` to obtain the muzzle position (`GetMuzzlePosition`), compute the reticle world target via `getReticleWorldTarget`, compute the corrected shoot direction, set `attackDir`, and send the projectile with `src` = muzzle position instead of firing from the player forward.
- Modified files: `src/actors/player/states/attackstate.ts` and `src/actors/player/states/aimrangeattackst.ts`.

### Testing
- Ran a local build attempt with `npm run build` to validate the change integration, but the build failed in this environment because `webpack` is not available (`sh: 1: webpack: not found`).
- Verified source changes with `git diff` and basic repository searches; no automated unit tests were present or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cd42b634c83239428223384818698)