### PR TITLE
Fix short StreakTracer length when aiming into empty space

### DIFF
--- a/src/actors/player/states/aimrangeattackst.ts
+++ b/src/actors/player/states/aimrangeattackst.ts
@@ -77,7 +77,8 @@ export class AimRangeAttackState extends AttackState implements IPlayerAction {
             dir: this.attackDir,
             range: this.attackDist,
             hitscan: true,
-            tracerLife: 2.12 // Slightly longer life for better visibility
+            tracerLife: 2.12, // Slightly longer life for better visibility
+            tracerRange: Math.max(this.attackDist, 100)
         })
         this.attackProcess = false
         return true

--- a/src/actors/projectile/projectile.ts
+++ b/src/actors/projectile/projectile.ts
@@ -45,6 +45,7 @@ export type ProjectileMsg = {
   // (2) hitscan 지원
   hitscan?: boolean;    // 오토건/라스건 = true
   tracerLife?: number;  // hitscan 트레이서 표시 시간(초) 예: 0.06~0.12
+  tracerRange?: number; // hitscan 트레이서 시각 길이(피해 판정 range와 분리)
 };
 
 export type ProjectileSet = {
@@ -59,7 +60,7 @@ export type ProjectileSet = {
     dir: THREE.Vector3;
     damage: number;
     ownerSpec: BaseSpec;
-    opt?: { hitscan?: boolean; tracerLife?: number };
+    opt?: { hitscan?: boolean; tracerLife?: number; tracerRange?: number };
   };
 };
 
@@ -156,7 +157,7 @@ export class Projectile implements ILoop {
     damage: number,
     ownerSpec: BaseSpec,
     range: number,
-    opt?: { hitscan?: boolean; tracerLife?: number }
+    opt?: { hitscan?: boolean; tracerLife?: number; tracerRange?: number }
   ): void;
   AllocateProjPool(
     a: ProjectileMsg | MonsterId,
@@ -165,7 +166,7 @@ export class Projectile implements ILoop {
     damage?: number,
     ownerSpec?: BaseSpec,
     range?: number,
-    opt?: { hitscan?: boolean; tracerLife?: number }
+    opt?: { hitscan?: boolean; tracerLife?: number; tracerRange?: number }
   ) {
     const msg: ProjectileMsg =
       typeof a === "object" && "id" in a
@@ -179,10 +180,15 @@ export class Projectile implements ILoop {
           range: range!,
           hitscan: opt?.hitscan,
           tracerLife: opt?.tracerLife,
+          tracerRange: opt?.tracerRange,
         } as ProjectileMsg);
 
     const id = msg.id;
-    const startOpt = { hitscan: msg.hitscan, tracerLife: msg.tracerLife };
+    const startOpt = {
+      hitscan: msg.hitscan,
+      tracerLife: msg.tracerLife,
+      tracerRange: msg.tracerRange,
+    };
 
     let pool = this.projectiles.get(id);
     if (!pool) {
@@ -263,7 +269,7 @@ export class Projectile implements ILoop {
     dir: THREE.Vector3,
     damage: number,
     ownerSpec: BaseSpec,
-    opt?: { hitscan?: boolean; tracerLife?: number }
+    opt?: { hitscan?: boolean; tracerLife?: number; tracerRange?: number }
   ) {
     set.releasing = false;
 

--- a/src/actors/projectile/projectilectrl.ts
+++ b/src/actors/projectile/projectilectrl.ts
@@ -49,6 +49,7 @@ export class ProjectileCtrl implements IActionUser {
   private isHitscan = false;
   private life = 0;
   private lifeMax = 0.08;
+  private tracerRange?: number;
   private hasAttacked = false;
 
   applyAction(action: IActionComponent, ctx?: ActionContext) {
@@ -70,6 +71,7 @@ export class ProjectileCtrl implements IActionUser {
     this.isHitscan = false;
     this.life = 0;
     this.lifeMax = 0.08;
+    this.tracerRange = undefined;
     this.hasAttacked = false;
   }
 
@@ -78,7 +80,7 @@ export class ProjectileCtrl implements IActionUser {
     dir: THREE.Vector3,
     damage: number,
     spec: BaseSpec,
-    opt?: { hitscan?: boolean; tracerLife?: number }
+    opt?: { hitscan?: boolean; tracerLife?: number; tracerRange?: number }
   ) {
     this.position.copy(src);
     this.prevPosition.copy(src);
@@ -100,6 +102,7 @@ export class ProjectileCtrl implements IActionUser {
     this.isHitscan = !!opt?.hitscan;
     this.life = 0;
     this.lifeMax = opt?.tracerLife ?? 0.08;
+    this.tracerRange = opt?.tracerRange;
     this.hasAttacked = false;
 
     if (this.isHitscan) {
@@ -107,7 +110,7 @@ export class ProjectileCtrl implements IActionUser {
       const nd = d.lengthSq() < 1e-8 ? new THREE.Vector3(0, 0, 1) : d.clone().normalize();
       this.moveDirection.copy(nd);
 
-      this.position.copy(src).addScaledVector(nd, this.range);
+      this.position.copy(src).addScaledVector(nd, this.tracerRange ?? this.range);
 
       // 트레이서 모델이라면 end까지 즉시 갱신
       this.projectile.update(this.position);


### PR DESCRIPTION
### Motivation
- When firing in hitscan mode into empty space the tracer collapsed to the short gameplay `range` (attack distance) because the tracer end was computed using the same `range` used for hit/damage logic.
- Aiming code computes a farther visual target when no collider is hit, so tracer visuals and gameplay distance were inconsistent, causing very short streaks when shooting at the sky.

### Description
- Added `tracerRange?: number` to `ProjectileMsg` to separate visual tracer length from damage `range` and threaded it through the projectile allocation and start APIs (`src/actors/projectile/projectile.ts`).
- Propagated `tracerRange` through pending pool start options so async-initialized projectiles preserve the visual range (`startOpt` / `pendingStart`).
- Updated `ProjectileCtrl` to store `tracerRange` and use `this.tracerRange ?? this.range` when computing the hitscan tracer end position, and to reset it on `Release` (`src/actors/projectile/projectilectrl.ts`).
- Updated `AimRangeAttackState` to include `tracerRange: Math.max(this.attackDist, 100)` when sending `EventTypes.Projectile` so tracers remain long/visible when no hit is found in front of the muzzle (`src/actors/player/states/aimrangeattackst.ts`).

### Testing
- Attempted automated build with `npm run build --silent` but it failed because the environment does not provide a local `webpack` binary (`sh: 1: webpack: not found`). No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1591424688323ab45a90fb0a83b36)