### PR TITLE
Fix hidden inventory tooltip intercepting touch after equip

### DIFF
--- a/src/ux/dialog/souldialog/core/tooltip.ts
+++ b/src/ux/dialog/souldialog/core/tooltip.ts
@@ -88,7 +88,11 @@ export class TooltipComponent {
     }
 
     public hide() {
-        if (this.tip) this.tip.setAttribute('data-show', 'false');
+        if (this.tip) {
+            this.tip.setAttribute('data-show', 'false');
+            this.tip.setAttribute('data-pinned', 'false');
+            this.tip.style.pointerEvents = 'none';
+        }
         this.pinned = false;
         this.targetIndex = null;
         this.targetId = null;


### PR DESCRIPTION
### Motivation
- On touch devices the inventory tooltip was opened pinned (with `pointer-events: auto`) to allow action button taps, but after using/equipping the code only hid the tooltip visually and did not always restore interaction state, allowing an invisible tooltip element to continue intercepting touch input.

### Description
- Updated `TooltipComponent.hide()` in `src/ux/dialog/souldialog/core/tooltip.ts` to also set `data-pinned="false"` and force `pointer-events: none` when hiding the tooltip.
- This ensures the tooltip no longer captures pointer events after it is hidden, resolving the touch-input blockage that occurred after equipping items from the inventory.

### Testing
- Attempted to run a project build with `npm run -s build`, but the build failed due to a missing `webpack` binary in the environment (`webpack: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a54178913c8323a8f32d362c3867a7)