### PR TITLE
Use muzzle bone direction for aim crosshair (fix vertical ADS movement)

### DIFF
--- a/src/actors/player/player.ts
+++ b/src/actors/player/player.ts
@@ -84,6 +84,14 @@ export class Player extends PhysicsObject {
         }
         mesh.getWorldPosition(target)
     }
+    GetMuzzleDirection(target: THREE.Vector3) {
+        const mesh = this.meshs.getObjectByName("muzzlePoint")
+        if (!mesh) {
+            this.meshs.getWorldDirection(target)
+            return
+        }
+        mesh.getWorldDirection(target)
+    }
     UnequipItem(bind: Bind) {
         const rightId = this.asset.GetBodyMeshId(bind)
         if (rightId == undefined) return

--- a/src/actors/player/states/attackstate.ts
+++ b/src/actors/player/states/attackstate.ts
@@ -205,7 +205,7 @@ export abstract class AttackState extends State implements IPlayerAction {
         this.player.GetMuzzlePosition(muzzlePos);
 
         const muzzleDir = new THREE.Vector3();
-        this.player.Meshs.getWorldDirection(muzzleDir);
+        this.player.GetMuzzleDirection(muzzleDir);
 
         this.raycast.set(muzzlePos, muzzleDir.normalize());
         this.raycast.far = maxDistance;


### PR DESCRIPTION
### Motivation
- ADS vertical aim moved the character spine but the crosshair raycast still used the root forward vector, so the reticle did not follow pitch changes.
- Make crosshair and muzzle raycasting reflect orbit-control pitch and upper-body bone rotation by sampling the actual muzzle orientation when available.

### Description
- Added `Player.GetMuzzleDirection(target: THREE.Vector3)` to read the forward direction from the `muzzlePoint` object and fall back to the character forward when missing (`src/actors/player/player.ts`).
- Replaced direct use of `Meshs.getWorldDirection` with `GetMuzzleDirection` inside `getMuzzleWorldTarget` so muzzle raycasts use the muzzle bone direction (`src/actors/player/states/attackstate.ts`).
- Behavior preserves the previous fallback and only changes the source of the direction vector used for muzzle-based aiming.

### Testing
- Attempted to run the build with `npm run -s build` but the environment lacks the `webpack` binary, causing the build to fail with `sh: 1: webpack: not found`.
- No automated unit tests were present or executed in this change set; changes are small and localized to aim/muzzle math and are ready for integration testing in a dev build once `webpack` is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7732b0c9c83238424fcbfe2a05223)