### PR TITLE
Make aim crosshair follow camera reticle pitch during ranged aim

### DIFF
--- a/src/actors/player/states/aimrangeattackst.ts
+++ b/src/actors/player/states/aimrangeattackst.ts
@@ -127,9 +127,9 @@ export class AimRangeAttackState extends AttackState implements IPlayerAction {
             targetPos.z
         );
 
-        // 🎯 추가: 총구 방향 충돌 지점에 가늠자 배치
-        const muzzleHitPoint = this.getMuzzleWorldTarget(100);
-        (this.playerCtrl.camera as any).setCrosshairWorldPosition(muzzleHitPoint);
+        // 🎯 가늠자는 카메라 중앙 레티클이 가리키는 실제 월드 지점을 따라가야
+        // orbit 상/하 회전 시에도 함께 위아래로 이동한다.
+        (this.playerCtrl.camera as any).setCrosshairWorldPosition(targetPos);
 
         if (this.attackProcess) return this
 

--- a/src/actors/player/states/rangeaimst.ts
+++ b/src/actors/player/states/rangeaimst.ts
@@ -79,9 +79,9 @@ export class RangeAimState extends AttackState implements IPlayerAction {
             targetPos.z
         );
 
-        // 🎯 추가: 총구 방향 충돌 지점에 가늠자 배치
-        const muzzleHitPoint = this.getMuzzleWorldTarget(100);
-        (this.playerCtrl.camera as any).setCrosshairWorldPosition(muzzleHitPoint);
+        // 🎯 가늠자는 카메라 중앙 레티클이 가리키는 실제 월드 지점을 따라가야
+        // orbit 상/하 회전 시에도 함께 위아래로 이동한다.
+        (this.playerCtrl.camera as any).setCrosshairWorldPosition(targetPos);
 
         const firePressed = this.playerCtrl.KeyState[KeyType.Action1] === true
         if (this.waitReleaseBeforeFire) {


### PR DESCRIPTION
### Motivation
- Improve aiming feedback so the on-screen crosshair follows the camera's reticle world target when the player orbits the camera up/down, making vertical camera motion visible in the crosshair position.

### Description
- In `RangeAimState` changed crosshair placement to use the camera reticle world target by calling `(this.playerCtrl.camera as any).setCrosshairWorldPosition(targetPos)` instead of the muzzle ray hit point.
- Applied the same change in `AimRangeAttackState` so crosshair movement is consistent while firing/holding fire.
- Kept projectile firing logic using muzzle-based targeting so shot direction and hit detection remain unchanged.

### Testing
- Ran `npm run build` which failed because `webpack` is not available in this environment (`sh: 1: webpack: not found`).
- Attempted a headless browser screenshot via Playwright which failed due to the runtime browser process crashing (SIGSEGV) in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a77626923c8323857b31c4b789afcb)