### PR TITLE
Improve aim pitch bone detection and fix parallax for ranged aiming

### DIFF
--- a/src/actors/player/player.ts
+++ b/src/actors/player/player.ts
@@ -229,12 +229,39 @@ export class Player extends PhysicsObject {
         this.spineAimPrevOffset.clear()
         this.currentAimPitch = 0
 
-        const candidates = ["mixamorigSpine", "mixamorigSpine1", "mixamorigSpine2", "mixamorigNeck"]
+        const candidates = [
+            // Mixamo
+            "mixamorigSpine", "mixamorigSpine1", "mixamorigSpine2", "mixamorigNeck",
+            // Blender/일반 FBX 네이밍
+            "Spine", "Spine1", "Spine2", "Neck",
+            // UE 계열 네이밍
+            "spine_01", "spine_02", "spine_03", "neck_01",
+        ]
+
         for (const name of candidates) {
             const bone = this.meshs.getObjectByName(name)
             if (!(bone instanceof THREE.Bone)) continue
+            if (this.spineAimBones.includes(bone)) continue
             this.spineAimBones.push(bone)
             this.spineAimPrevOffset.set(bone, new THREE.Quaternion())
+        }
+
+        // 명시적 이름 매칭 실패 시, 스켈레톤에서 spine/neck/chest 계열 본을 자동 탐색
+        if (this.spineAimBones.length == 0) {
+            const discovered: THREE.Bone[] = []
+            this.meshs.traverse(obj => {
+                if (!(obj instanceof THREE.Bone)) return
+                const lowerName = obj.name.toLowerCase()
+                if (lowerName.includes("spine") || lowerName.includes("neck") || lowerName.includes("chest")) {
+                    discovered.push(obj)
+                }
+            })
+
+            discovered.sort((a, b) => a.name.localeCompare(b.name))
+            for (const bone of discovered) {
+                this.spineAimBones.push(bone)
+                this.spineAimPrevOffset.set(bone, new THREE.Quaternion())
+            }
         }
     }
 
@@ -267,8 +294,9 @@ export class Player extends PhysicsObject {
         const from = new THREE.Vector3()
         chestLikeBone.getWorldPosition(from)
 
-        const localDir = this.meshs.worldToLocal(this.aimPitchTarget.clone()).sub(this.meshs.worldToLocal(from.clone())).normalize()
-        let targetPitch = Math.atan2(localDir.y, localDir.z)
+        const toTarget = new THREE.Vector3().subVectors(this.aimPitchTarget, from)
+        const horizontalDist = Math.sqrt(toTarget.x * toTarget.x + toTarget.z * toTarget.z)
+        let targetPitch = Math.atan2(toTarget.y, Math.max(0.0001, horizontalDist))
         targetPitch = THREE.MathUtils.clamp(targetPitch, -this.spineAimPitchMaxDown, this.spineAimPitchMaxUp)
 
         this.currentAimPitch = THREE.MathUtils.lerp(

--- a/src/actors/player/states/aimrangeattackst.ts
+++ b/src/actors/player/states/aimrangeattackst.ts
@@ -119,17 +119,18 @@ export class AimRangeAttackState extends AttackState implements IPlayerAction {
 
         // 🎯 핵심 개선: 조준 시차(Parallax) 수정
         // 화면 중앙 조준점이 가리키는 월드 상의 실제 지점을 찾고 캐릭터가 그곳을 바라보게 합니다.
-        const targetPos = this.getReticleWorldTarget(100); 
-        this.player.SetAimTarget(targetPos)
+        const targetPos = this.getReticleWorldTarget(100);
+        const bodyAimTarget = this.getCameraForwardWorldTarget(1000)
+        this.player.SetAimTarget(bodyAimTarget)
         this.player.Meshs.lookAt(
             targetPos.x,
             this.player.Pos.y,
             targetPos.z
         );
 
-        // 🎯 추가: 총구 방향 충돌 지점에 가늠자 배치
-        const muzzleHitPoint = this.getMuzzleWorldTarget(100);
-        (this.playerCtrl.camera as any).setCrosshairWorldPosition(muzzleHitPoint);
+        // 🎯 가늠자는 카메라 중앙 레티클이 가리키는 실제 월드 지점을 따라가야
+        // orbit 상/하 회전 시에도 함께 위아래로 이동한다.
+        (this.playerCtrl.camera as any).setCrosshairWorldPosition(targetPos);
 
         if (this.attackProcess) return this
 

--- a/src/actors/player/states/attackstate.ts
+++ b/src/actors/player/states/attackstate.ts
@@ -179,6 +179,15 @@ export abstract class AttackState extends State implements IPlayerAction {
     }
 
 
+
+    protected getCameraForwardWorldTarget(distance = AttackState.FAR_AIM_DISTANCE): THREE.Vector3 {
+        const forward = new THREE.Vector3()
+        this.playerCtrl.camera.getWorldDirection(forward)
+        return new THREE.Vector3()
+            .copy(this.playerCtrl.camera.position)
+            .add(forward.multiplyScalar(distance))
+    }
+
     private isPlayerOwnedObject(obj: THREE.Object3D): boolean {
         let current: THREE.Object3D | null = obj
         while (current) {

--- a/src/actors/player/states/rangeaimst.ts
+++ b/src/actors/player/states/rangeaimst.ts
@@ -68,8 +68,9 @@ export class RangeAimState extends AttackState implements IPlayerAction {
 
         // 🎯 핵심 개선: 조준 시차(Parallax) 수정
         // 1. 화면 중앙 조준점이 가리키는 월드 상의 실제 지점을 찾습니다.
-        const targetPos = this.getReticleWorldTarget(100); 
-        this.player.SetAimTarget(targetPos)
+        const targetPos = this.getReticleWorldTarget(100);
+        const bodyAimTarget = this.getCameraForwardWorldTarget(1000)
+        this.player.SetAimTarget(bodyAimTarget)
 
         // 2. 캐릭터가 그 지점을 바라보게 합니다.
         // Y축은 캐릭터의 높이를 유지하여 캐릭터가 앞으로 고꾸라지거나 뒤로 젖혀지지 않게 합니다.
@@ -79,9 +80,9 @@ export class RangeAimState extends AttackState implements IPlayerAction {
             targetPos.z
         );
 
-        // 🎯 추가: 총구 방향 충돌 지점에 가늠자 배치
-        const muzzleHitPoint = this.getMuzzleWorldTarget(100);
-        (this.playerCtrl.camera as any).setCrosshairWorldPosition(muzzleHitPoint);
+        // 🎯 가늠자는 카메라 중앙 레티클이 가리키는 실제 월드 지점을 따라가야
+        // orbit 상/하 회전 시에도 함께 위아래로 이동한다.
+        (this.playerCtrl.camera as any).setCrosshairWorldPosition(targetPos);
 
         const firePressed = this.playerCtrl.KeyState[KeyType.Action1] === true
         if (this.waitReleaseBeforeFire) {


### PR DESCRIPTION
### Motivation
- Fix unreliable spine/neck bone detection across different rig naming conventions and ensure stable aim pitch behavior. 
- Correct parallax between camera reticle and body aiming so the character looks toward a stable world point while the HUD reticle follows the camera ray.

### Description
- Extended spine/neck bone candidate list in `src/actors/player/player.ts` to include Mixamo, Blender/FBX, and UE-style names and added a fallback traversal that automatically collects bones whose names contain `spine`, `neck`, or `chest` when explicit names are not found. 
- Prevent duplicate bone entries and initialize previous-offset quaternions for discovered bones. 
- Rewrote aim pitch calculation in `player.ts` to compute pitch from the vector from chest to target using horizontal distance (with a small epsilon) and clamped lerp smoothing. 
- Added `getCameraForwardWorldTarget` to `src/actors/player/states/attackstate.ts` to produce a distant camera-forward world point for body-facing. 
- Updated `RangeAimState` and `AimRangeAttackState` (`src/actors/player/states/rangeaimst.ts` and `.../aimrangeattackst.ts`) to set the player's aim target to the camera-forward world point (so the body aims at a stable far target) while keeping the HUD crosshair positioned at the actual reticle hit point returned by the screen-center raycast.

### Testing
- Ran project build with `npm run build` which completed successfully. 
- Executed automated test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a77626923c8323857b31c4b789afcb)