### PR TITLE
Introduce unified action resource cost service and wire skill/attack costs

### DIFF
--- a/src/actions/actiontypes.ts
+++ b/src/actions/actiontypes.ts
@@ -1,5 +1,6 @@
 import { CharacterStatus } from "@Glibs/actors/battle/charstatus"
 import { StatSystem } from "@Glibs/inventory/stat/statsystem"
+import { cost } from "@Glibs/actors/battle/resourcecosttypes"
 
 export interface IActionUser {
   name?: string
@@ -362,6 +363,10 @@ export const actionDefs = {
     type: "projectileFire",
     castAction: "MagicH1",
     cooldown: 3,
+    resourceCost: {
+      id: "skill_fireball_cast",
+      cost: cost.any(cost.atom("mp", 8), cost.atom("stamina", 12))
+    },
     levels: [
       { damage: 10, radius: 1.0, speed: 10 },
       { damage: 15, radius: 1.2, speed: 10 },
@@ -375,6 +380,10 @@ export const actionDefs = {
     type: "meteor",
     castAction: "MagicH2",
     cooldown: 7,
+    resourceCost: {
+      id: "skill_meteor_cast",
+      cost: cost.any(cost.atom("mp", 20), cost.atom("stamina", 30))
+    },
     distance: 8,
     fallDuration: 0.65,
     ringRadius: 1.9,

--- a/src/actors/battle/actioncostservice.ts
+++ b/src/actors/battle/actioncostservice.ts
@@ -1,0 +1,35 @@
+import IInventory from "@Glibs/interface/iinven"
+import { ItemId } from "@Glibs/inventory/items/itemdefs"
+import { ResourceChangedPayload } from "@Glibs/types/globaltypes"
+import { BaseSpec } from "./basespec"
+import { CombatResourcePool, CostEngine } from "./resourcecost"
+import { ActionCostSpec } from "./resourcecosttypes"
+
+export type ActionCostConsumeOptions = {
+  inventory?: IInventory
+  consumeInventoryItem?: (id: ItemId, count: number) => void
+  actorId?: string
+  sourceId?: string
+  onResourceChanged?: (payload: ResourceChangedPayload) => void
+}
+
+export class ActionCostService {
+  private readonly costEngine = new CostEngine()
+
+  tryConsume(spec: ActionCostSpec, baseSpec: BaseSpec, options?: ActionCostConsumeOptions) {
+    const pool = new CombatResourcePool({
+      spec: baseSpec,
+      inventory: options?.inventory,
+      consumeInventoryItem: options?.consumeInventoryItem,
+      actorId: options?.actorId,
+      sourceId: options?.sourceId ?? spec.id,
+      onResourceChanged: options?.onResourceChanged,
+    })
+
+    const resolved = this.costEngine.resolve(spec, pool)
+    if (!resolved.ok) return false
+    return this.costEngine.commit(resolved, pool)
+  }
+}
+
+export const actionCostService = new ActionCostService()

--- a/src/actors/battle/basespec.ts
+++ b/src/actors/battle/basespec.ts
@@ -9,8 +9,6 @@ import { Buff } from "@Glibs/magical/buff/buff"
 import { CharacterStatus } from "./charstatus"
 import { StatFactory } from "./statfactory"
 import { calculateCompositeDamage, DamageContext, DamageResult } from "./damagecalc"
-import IEventController from "@Glibs/interface/ievent"
-import { EventTypes } from "@Glibs/types/globaltypes"
 import { DamageFormula } from "./damageformula"
 
 export class BaseSpec {

--- a/src/actors/player/playerctrl.ts
+++ b/src/actors/player/playerctrl.ts
@@ -25,6 +25,8 @@ import { ComboMeleeState } from "./states/combomeleeattackst";
 import { EventActionState, EventIdleState } from "./states/eventstate";
 import { Bind } from "@Glibs/types/assettypes";
 import { MonDrop } from "../monsters/monstertypes";
+import { ActionCostSpec } from "@Glibs/actors/battle/resourcecosttypes";
+import { actionCostService } from "@Glibs/actors/battle/actioncostservice";
 
 type LearnedSkillMessage = {
     nodeId: string
@@ -426,6 +428,10 @@ export class PlayerCtrl implements ILoop, IActionUser {
 
         if (!action) return false
 
+        if (!this.tryConsumeSkillCost(this.resolveSkillCostSpec(skill, action), "스킬을 시전할 자원이 부족합니다.")) {
+            return false
+        }
+
         const targetAction = action
         const context: ActionContext = {
             source: this,
@@ -448,6 +454,37 @@ export class PlayerCtrl implements ILoop, IActionUser {
         }
 
         runCast()
+        return true
+    }
+
+    private resolveSkillCostSpec(skill: LearnedSkillMessage, action: IActionComponent): ActionCostSpec | undefined {
+        const skillCost = (skill.tech as { resourceCost?: ActionCostSpec } | undefined)?.resourceCost
+        if (skillCost) return skillCost
+
+        const actionCost = (action as { resourceCost?: ActionCostSpec } | undefined)?.resourceCost
+        return actionCost
+    }
+
+    private tryConsumeSkillCost(spec: ActionCostSpec | undefined, failMessage: string) {
+        if (!spec) return true
+
+        const ok = actionCostService.tryConsume(spec, this.baseSpec, {
+            inventory: this.inventory,
+            consumeInventoryItem: (id: ItemId, count: number) => {
+                this.eventCtrl.SendEventMessage(EventTypes.UseItem, id, count)
+            },
+            actorId: "player",
+            sourceId: spec.id,
+            onResourceChanged: (payload) => {
+                this.eventCtrl.SendEventMessage(EventTypes.ResourceChanged + "player", payload)
+            },
+        })
+
+        if (!ok) {
+            this.eventCtrl.SendEventMessage(EventTypes.AlarmWarning, failMessage)
+            return false
+        }
+
         return true
     }
 

--- a/src/actors/player/states/attackstate.ts
+++ b/src/actors/player/states/attackstate.ts
@@ -13,8 +13,8 @@ import { Bind } from "@Glibs/types/assettypes";
 import { ActionType } from "../playertypes";
 import { IItem } from "@Glibs/interface/iinven";
 import { Item } from "@Glibs/inventory/items/item";
-import { CombatResourcePool, CostEngine } from "@Glibs/actors/battle/resourcecost";
 import { ActionCostSpec } from "@Glibs/actors/battle/resourcecosttypes";
+import { actionCostService } from "@Glibs/actors/battle/actioncostservice";
 import { ItemId } from "@Glibs/inventory/items/itemdefs";
 
 export abstract class AttackState extends State implements IPlayerAction {
@@ -140,16 +140,12 @@ export abstract class AttackState extends State implements IPlayerAction {
     }
 
 
-    protected readonly costEngine = new CostEngine()
-
-
     protected resolveAttackCostSpec(itemInfo: IItem | null | undefined, fallback: ActionCostSpec): ActionCostSpec {
         return itemInfo?.ResourceCost ?? fallback
     }
 
     protected tryConsumeAttackCost(spec: ActionCostSpec, failMessage = "자원이 부족합니다.") {
-        const pool = new CombatResourcePool({
-            spec: this.baseSpec,
+        const ok = actionCostService.tryConsume(spec, this.baseSpec, {
             inventory: this.playerCtrl.inventory,
             consumeInventoryItem: (id: ItemId, count: number) => {
                 this.eventCtrl.SendEventMessage(EventTypes.UseItem, id, count)
@@ -161,13 +157,7 @@ export abstract class AttackState extends State implements IPlayerAction {
             },
         })
 
-        const resolved = this.costEngine.resolve(spec, pool)
-        if (!resolved.ok) {
-            this.eventCtrl.SendEventMessage(EventTypes.AlarmWarning, failMessage)
-            return false
-        }
-
-        if (!this.costEngine.commit(resolved, pool)) {
+        if (!ok) {
             this.eventCtrl.SendEventMessage(EventTypes.AlarmWarning, failMessage)
             return false
         }


### PR DESCRIPTION
### Motivation
- Introduce a reusable resource-cost resolution/commit path so skills and attacks can declare and consume resource costs consistently.
- Attach resource cost metadata to actions (e.g. FireBall, Meteor) to enable multi-resource costs and fallback behaviors.

### Description
- Added `ActionCostService` (`src/actors/battle/actioncostservice.ts`) which wraps `CostEngine`/`CombatResourcePool` and exposes `tryConsume` for consuming action costs.
- Wired skill casting in `PlayerCtrl` to resolve and consume an `ActionCostSpec` before running a cast by adding `resolveSkillCostSpec` and `tryConsumeSkillCost`, and sending relevant events on failure or resource changes.
- Replaced inlined `CostEngine`/`CombatResourcePool` usage in `AttackState` with `actionCostService.tryConsume` and simplified the attack cost consumption flow.
- Added `resourceCost` specs to `FireBall` and `Meteor` in `actionDefs` and imported the `cost` helper in `actiontypes` to define multi-resource costs.

### Testing
- No new automated unit tests were added for this change.
- Please verify via the project's CI which runs the TypeScript build/typecheck and existing test suite (CI should validate compilation and integration with the new service).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa08faefdc8323bb4e59600b893630)