### PR TITLE
Adjust galaxy UI placement by screen orientation and focus centering

### DIFF
--- a/src/world/galaxy/galaxymapui.ts
+++ b/src/world/galaxy/galaxymapui.ts
@@ -1,5 +1,32 @@
 import { PlanetInfoViewModel } from "./galaxytypes";
 
+const GALAXY_UI_PANEL_WIDTH = 340;
+const GALAXY_UI_GAP = 14;
+const GALAXY_UI_BOTTOM_PANEL_HEIGHT = 260;
+
+export function getGalaxyFocusCenterNdc(viewportWidth: number, viewportHeight: number): { x: number; y: number } {
+  const safeWidth = Math.max(1, viewportWidth);
+  const safeHeight = Math.max(1, viewportHeight);
+
+  if (safeWidth >= safeHeight) {
+    const reservedWidth = GALAXY_UI_PANEL_WIDTH + GALAXY_UI_GAP * 2;
+    const remainingWidth = Math.max(1, safeWidth - reservedWidth);
+    const centerX = remainingWidth * 0.5;
+    return {
+      x: (centerX / safeWidth) * 2 - 1,
+      y: 0
+    };
+  }
+
+  const reservedHeight = GALAXY_UI_BOTTOM_PANEL_HEIGHT + GALAXY_UI_GAP * 2;
+  const remainingHeight = Math.max(1, safeHeight - reservedHeight);
+  const centerY = remainingHeight * 0.5;
+  return {
+    x: 0,
+    y: 1 - (centerY / safeHeight) * 2
+  };
+}
+
 export class GalaxyMapUI {
   private root: HTMLDivElement;
   private planetName!: HTMLElement;
@@ -68,6 +95,8 @@ export class GalaxyMapUI {
 
     container.appendChild(this.root);
     this.cacheRefs();
+    this.updateLayoutMode();
+    window.addEventListener("resize", this.updateLayoutMode);
   }
 
   updatePlanet(info: PlanetInfoViewModel): void {
@@ -94,8 +123,15 @@ export class GalaxyMapUI {
   }
 
   dispose(): void {
+    window.removeEventListener("resize", this.updateLayoutMode);
     this.root.remove();
   }
+
+  private updateLayoutMode = (): void => {
+    const landscape = window.innerWidth >= window.innerHeight;
+    this.root.classList.toggle("gsm-layout-landscape", landscape);
+    this.root.classList.toggle("gsm-layout-portrait", !landscape);
+  };
 
   private cacheRefs(): void {
     const q = (name: string) => this.root.querySelector(`[data-ref="${name}"]`) as HTMLElement;
@@ -128,6 +164,11 @@ export class GalaxyMapUI {
       }
       .gsm-panel { right:14px; top:14px; width:340px; padding:14px; }
       .gsm-legend-panel { right:14px; bottom:14px; width:340px; padding:12px 14px; font-size:12px; line-height:1.5; }
+      .gsm-layout-portrait .gsm-panel {
+        left:14px; right:14px; top:auto; bottom:14px; width:auto; max-width:none;
+        max-height:calc(100vh - 28px); overflow:auto;
+      }
+      .gsm-layout-portrait .gsm-legend-panel { display:none; }
       .gsm-planet-title { display:flex; align-items:center; gap:8px; margin-bottom:8px; font-size:20px; font-weight:700; flex-wrap:wrap; }
       .gsm-small { color:#aeb8cc; }
       .gsm-badge {

--- a/src/world/galaxy/galaxyplanetnetwork.ts
+++ b/src/world/galaxy/galaxyplanetnetwork.ts
@@ -7,6 +7,7 @@ import {
   PlanetDef,
   PlanetInfoViewModel
 } from "./galaxytypes";
+import { getGalaxyFocusCenterNdc } from "./galaxymapui";
 import IEventController, { ILoop } from "@Glibs/interface/ievent";
 import { IWorldMapObject, MapEntryType } from "../worldmap/worldmaptypes";
 import { EventTypes } from "@Glibs/types/globaltypes";
@@ -307,17 +308,18 @@ export class GalaxyPlanetNetwork implements ILoop, IWorldMapObject {
 
     const selected = this.planets[index];
     const target = selected.userData.basePosition.clone();
+    const shiftedTarget = this.getFocusAreaCenterWorld(target);
 
     let dir = this.camera.position.clone().sub(this.currentTarget());
     if (dir.lengthSq() < 0.0001) dir.set(0.55, 0.36, 1.0);
     dir.normalize();
 
     const dist = (this.options!.focus.distance ?? 32) + selected.userData.radius * 4.0;
-    const endPos = target.clone()
+    const endPos = shiftedTarget.clone()
       .add(dir.multiplyScalar(dist))
       .add(new THREE.Vector3(0, dist * 0.06, 0));
 
-    this.startCameraTween(endPos, target, this.options!.focus.tweenSeconds ?? 1, () => {
+    this.startCameraTween(endPos, shiftedTarget, this.options!.focus.tweenSeconds ?? 1, () => {
       if (this.controls) {
         this.controls.minDistance = Math.max(10, dist * 0.55);
         this.controls.maxDistance = dist * 2.4;
@@ -824,6 +826,22 @@ export class GalaxyPlanetNetwork implements ILoop, IWorldMapObject {
 
   private currentTarget(): THREE.Vector3 {
     return this.controls?.target ?? this.internalTarget;
+  }
+
+  private getFocusAreaCenterWorld(target: THREE.Vector3): THREE.Vector3 {
+    const ndc = getGalaxyFocusCenterNdc(window.innerWidth, window.innerHeight);
+    if (Math.abs(ndc.x) < 0.0001 && Math.abs(ndc.y) < 0.0001) return target.clone();
+
+    const viewDir = this.camera.getWorldDirection(new THREE.Vector3());
+    const depth = Math.max(0.001, target.clone().sub(this.camera.position).dot(viewDir));
+
+    const projected = target.clone().project(this.camera);
+    projected.x -= ndc.x;
+    projected.y -= ndc.y;
+
+    const rayPoint = new THREE.Vector3(projected.x, projected.y, 0.5).unproject(this.camera);
+    const rayDir = rayPoint.sub(this.camera.position).normalize();
+    return this.camera.position.clone().add(rayDir.multiplyScalar(depth));
   }
 
   private computeOverviewState(): void {


### PR DESCRIPTION
### Motivation
- Prevent the UI panel from covering planets by positioning the info panel in the remaining visible area depending on screen orientation and center focused planets inside that usable region rather than the absolute screen center.

### Description
- Added `getGalaxyFocusCenterNdc` and constants to `src/world/galaxy/galaxymapui.ts` to compute the UI-reserved area and return an NDC offset representing the usable viewport center.
- Made `GalaxyMapUI` responsive by adding `updateLayoutMode`, CSS rules and a resize listener so the main panel stays on the right in landscape and moves to the bottom (hiding the legend) in portrait, and cleaned up the listener in `dispose`.
- Updated `src/world/galaxy/galaxyplanetnetwork.ts` to import the helper and added `getFocusAreaCenterWorld`, then use a `shiftedTarget` for camera tweening so focused planets appear centered within the UI-free region.
- Files changed: `src/world/galaxy/galaxymapui.ts` and `src/world/galaxy/galaxyplanetnetwork.ts`.

### Testing
- Ran `npm run build` which failed in this environment with `webpack: not found` (environmental tool missing), so build could not be validated here (failed).
- Ran `npx tsc --noEmit` which failed due to existing project-wide missing/ambient type and dependency errors unrelated to these changes (failed).
- Attempted a Playwright page capture to visually verify layout, but there was no running app endpoint (`http://127.0.0.1:8080` returned `ERR_EMPTY_RESPONSE`), so visual validation could not be performed (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af90baa8c48323ab9e88ff6b85ec45)