### PR TITLE
Add controllable actor subsystem (controller, policies, types, samples, and docs)

### DIFF
--- a/docs/controllable-structure-review.md
+++ b/docs/controllable-structure-review.md
@@ -1,0 +1,92 @@
+# Controllable 구조 개선 리뷰 (최종 점검)
+
+현재 `src/actors/controllable` 스캐폴딩은 시작점으로 충분하지만,
+실전 투입 전에는 아래 개선을 우선순위대로 진행하는 것을 권장합니다.
+
+---
+
+## P0 (먼저 해야 하는 항목)
+
+## 1) Command/State 타입 안정성 강화
+- 현재 `payload?: unknown`, `stateFactory(...params: unknown[])` 형태라 런타임 캐스팅이 필요합니다.
+- 개선안:
+  - `Command`를 discriminated union으로 분리 (`MoveCommand`, `AttackCommand` ...)
+  - `stateFactory(runtime: IControllableRuntime, ctx: BuildContext)`처럼 시그니처 고정
+- 기대효과: `as` 캐스팅 감소, IDE 자동완성 개선, 명령 처리 버그 감소.
+
+## 2) Arbiter를 클래스화 + 충돌정책 표준화
+- 현재 기본 arbiter는 priority 정렬만 수행합니다.
+- 개선안:
+  - `ICommandArbiter` 인터페이스 도입
+  - 정책 분리: `humanOverrideWindow`, `dropConflicts`, `mergeParallelizable`
+- 기대효과: hybrid 정책 실험/튜닝 용이.
+
+## 3) Command Queue 보호장치
+- 큐 길이 제한/TTL/중복 제거가 아직 없습니다.
+- 개선안:
+  - `maxQueueSize`
+  - 오래된 명령 폐기(`issuedAt + ttl`)
+  - 동일 command coalesce(예: 연속 move)
+- 기대효과: 프레임 저하/메모리 증가 방지.
+
+---
+
+## P1 (다음 스프린트 권장)
+
+## 4) 이벤트 브리지 레이어 추가
+- `EventTypes`는 추가했지만 실제 브리지(`IssueControllableCommand` -> `Controllables.issue`)가 없습니다.
+- 개선안:
+  - `ControllableEventBridge` 추가
+  - 입력/UI/AI 모두 이벤트 발행만 하도록 통일
+- 기대효과: 시스템 결합도 감소, 테스트 용이.
+
+## 5) 선택/그룹 명령 API 정리
+- 현재 `issueGroup(commands[])`는 호출자가 actorId를 모두 채워야 합니다.
+- 개선안:
+  - `issueSelected(templateCommand)` 추가
+  - 내부에서 selected actorId에 맞춰 명령 fan-out
+- 기대효과: UI 코드 단순화.
+
+## 6) 샘플 정의를 실사용 팩토리로 연결
+- 샘플(`samples/controllabledefs.ts`)은 존재하지만 bootstrapping 코드가 없습니다.
+- 개선안:
+  - `registerSampleDefinitions()`를 게임 초기화에 연결
+  - `PolicyRegistry`에 `human`, `ship-default-ai`, `ally-escort-ai` 등록
+- 기대효과: 데모 가능한 최소 end-to-end 동작 확보.
+
+---
+
+## P2 (운영 전 품질 강화)
+
+## 7) 테스트 추가
+- 단위 테스트:
+  - `ControllableCtrl.resolveSources()`
+  - arbiter 충돌 해결
+  - `HumanPolicy` enqueue/tick 동작
+- 통합 테스트:
+  - hybrid 모드에서 human 입력 후 AI 복귀 시나리오
+  - group command fan-out 시나리오
+
+## 8) 관측성(Observability)
+- 개선안:
+  - command trace 로그(issuer, source, latency)
+  - dropped command 카운터
+  - state transition 로그
+- 기대효과: 디버깅 시간 단축.
+
+## 9) 네트워크/리플레이 대비
+- 개선안:
+  - `ActorCommand` 직렬화 스키마(version 포함)
+  - 결정적 시뮬레이션을 위한 timestamp 정책 확정
+- 기대효과: 멀티플레이/리플레이 확장 준비.
+
+---
+
+## 추천 실행 순서
+1. P0-1, P0-2, P0-3
+2. P1-4, P1-5
+3. P1-6 (샘플 실연결)
+4. P2 테스트/관측성
+
+위 순서대로 진행하면 현재 구조를 크게 깨지 않으면서,
+"수동 + AI 하이브리드 제어"를 안정적으로 운영 가능한 수준까지 올릴 수 있습니다.

--- a/docs/controlled-actor-extension.md
+++ b/docs/controlled-actor-extension.md
@@ -1,0 +1,187 @@
+# 조작/명령 가능 Actor 확장 가이드 (수동 + AI 동시 지원)
+
+요구사항이 "Ship + Squad 통합"이면서 동시에
+
+1. 사람이 직접 조작(수동 control)
+2. AI/알고리즘이 조작(자동 control)
+
+두 가지를 모두 지원해야 한다면,
+핵심은 **입력 장치가 아니라 `명령(Command)`을 표준화**하는 것입니다.
+
+---
+
+## 1) 권장 아키텍처 한 줄 요약
+
+- `Model`(표현)
+- `Ctrl`(실행기)
+- `State`(행동)
+- `Policy`(명령 생성기: Human/AI)
+
+즉, 컨트롤러는 "명령을 받아 실행"만 하고,
+명령을 "누가 만들었는지"(사람/AI)는 Policy 계층으로 분리합니다.
+
+---
+
+## 2) monsters 패턴과 결합 포인트
+
+기존 `actors/monsters`는 이미 아래 구조를 갖고 있습니다.
+
+- `MonsterDb`: 정의/메타데이터
+- `CreateMon`: 정의 기반 생성
+- `MonsterCtrl`: 공통 update/전투 실행
+- `idleStates`: 타입별 행동 전략
+
+컨트롤 가능한 아군도 동일하게 가되,
+`Policy`를 하나 추가해서 "명령 생성" 책임을 외부로 분리하면 됩니다.
+
+---
+
+## 3) 통합 구조 (Ship/Squad 공통)
+
+```text
+src/actors/controllable/
+  controllabletypes.ts
+  controllabledb.ts
+  createcontrollable.ts
+  controllable.ts
+  controllablectrl.ts
+  controllables.ts            // 선택/그룹 명령 매니저
+  policy/
+    controlpolicy.ts          // 공통 인터페이스
+    humanpolicy.ts            // 입력/클릭 -> Command
+    aipolicy.ts               // BT/GOAP/RL -> Command
+  states/
+    controllablestate.ts
+    defaultstate.ts
+    shipstate.ts
+    allystate.ts
+```
+
+Ship/Squad를 나누는 기준은 클래스가 아니라 `define(role, stateFactory, policyHint)`입니다.
+
+---
+
+## 4) 핵심 타입 설계
+
+### A. 명령 타입 (공통 언어)
+
+```ts
+export type CommandType =
+  | "move"
+  | "attack"
+  | "hold"
+  | "follow"
+  | "patrol"
+  | "useSkill";
+
+export type Command = {
+  type: CommandType;
+  actorId: string;
+  targetId?: string;
+  point?: THREE.Vector3;
+  issuedAt: number;
+  issuer: "human" | "ai" | "script";
+  priority?: number;
+};
+```
+
+### B. 제어 소스 타입
+
+```ts
+export type ControlSource = "manual" | "ai" | "hybrid";
+```
+
+### C. Policy 인터페이스 (명령 생성기)
+
+```ts
+export interface IControlPolicy {
+  source: ControlSource;
+  tick(delta: number, ctx: PolicyContext): Command[];
+  onEvent?(event: unknown, ctx: PolicyContext): void;
+}
+```
+
+- `HumanPolicy`: 키/마우스/UI 이벤트를 Command로 변환
+- `AiPolicy`: 센서 정보(적 거리, hp, 쿨다운)를 보고 Command 생성
+
+---
+
+## 5) Controller 책임 최소화
+
+`ControllableCtrl`은 아래만 담당해야 합니다.
+
+1. Policy가 만든 Command를 큐에 적재
+2. 우선순위/쿨다운/자원 조건 검증
+3. State 전환 (`Idle -> Move -> Attack ...`)
+4. `BaseSpec`, `IActionUser`로 전투/버프 처리
+
+즉 컨트롤러는 **결정(decision)**이 아니라 **실행(execution)** 엔진입니다.
+
+---
+
+## 6) 수동 + AI 동시 지원 방식 (중요)
+
+### 권장: Hybrid 모드 + 우선순위 규칙
+
+`ControlSource = "hybrid"`일 때 다음 룰을 권장합니다.
+
+- 최근 N초 내 human 입력이 있으면 human 우선
+- human 입력이 없으면 ai 명령 활성화
+- 같은 틱에 충돌 시 `priority` 높은 명령 채택
+- 이동과 공격처럼 병행 가능한 명령은 병렬 허용
+
+예:
+- 플레이어가 이동을 찍으면 즉시 수동 명령 우선
+- 입력이 끊기면 AI가 자동 추적/호위 재개
+
+이 구조가 "직접 조작 ↔ 자동 전투" 전환 UX를 가장 자연스럽게 만듭니다.
+
+---
+
+## 7) Event 버스 설계
+
+기존 이벤트 시스템을 재사용하면서 아래만 추가하세요.
+
+- `SetControlSource(actorId, source)`
+- `IssueControllableCommand(command)`
+- `IssueControllableGroupCommand(commands[])`
+
+UI는 이벤트 발행만 하고,
+`HumanPolicy`는 UI 이벤트를 Command로 변환,
+`AiPolicy`는 월드 상태를 읽어 Command를 생성합니다.
+
+---
+
+## 8) 상태(State) 설계 팁
+
+State는 "누가 명령했는지"를 몰라도 되게 유지하세요.
+
+- State 입력은 Command/Context만 받기
+- 출처(human/ai)는 Ctrl 또는 Policy 계층에서 해석
+
+이렇게 하면 Ship/Ally 상태를 재사용하기 쉽고,
+AI 모델을 바꿔도 State 코드는 거의 건드리지 않습니다.
+
+---
+
+## 9) 단계별 적용 순서
+
+1. `Command`와 `IControlPolicy` 먼저 고정
+2. `ControllableCtrl`을 command-driven으로 변경
+3. `HumanPolicy` 연결 (기존 입력 이식)
+4. `AiPolicy` 연결 (간단 규칙 기반부터 시작)
+5. `hybrid` arbitration 룰 추가
+6. 마지막에 Ship/Ally stateFactory 분기 최적화
+
+---
+
+## 10) 결론
+
+질문하신 요구사항에는
+**"통합 컨트롤러 + 이원화된 Policy(Human/AI) + 공통 Command 버스"** 구조가 가장 적합합니다.
+
+- Ship/Squad 중복 코드 최소화
+- 수동/자동 전환 비용 최소화
+- AI 알고리즘 교체(규칙 기반 → BT/GOAP/RL)에도 안전
+
+원하시면 다음 단계로 `controlpolicy.ts`, `humanpolicy.ts`, `aipolicy.ts`, `controllablectrl.ts` 최소 템플릿을 실제 코드로 바로 추가해드릴게요.

--- a/src/actors/controllable/controllablectrl.ts
+++ b/src/actors/controllable/controllablectrl.ts
@@ -1,0 +1,117 @@
+import { BaseSpec } from "@Glibs/actors/battle/basespec"
+import IEventController, { ILoop } from "@Glibs/interface/ievent"
+import { IActionComponent, IActionUser, ActionContext } from "@Glibs/types/actiontypes"
+import { EventTypes } from "@Glibs/types/globaltypes"
+import {
+  ActorCommand,
+  CommandArbiter,
+  CommandContext,
+  ControlSource,
+  IControllableRuntime,
+  IControllableState,
+  PolicyContext,
+} from "./controllabletypes"
+import { IControlPolicy } from "./policy/controlpolicy"
+
+export class ControllableCtrl implements ILoop, IActionUser {
+  LoopId = 0
+  actions: IActionComponent[] = []
+  commandQueue: ActorCommand[] = []
+
+  private lastHumanCommandAt = 0
+  private activeSource: ControlSource
+
+  readonly baseSpec: BaseSpec
+
+  constructor(
+    public name: string,
+    private runtime: IControllableRuntime,
+    private eventCtrl: IEventController,
+    private state: IControllableState,
+    private policies: Partial<Record<ControlSource, IControlPolicy>>,
+    stats: ConstructorParameters<typeof BaseSpec>[0],
+    private arbiter: CommandArbiter = ControllableCtrl.defaultArbiter,
+    private readonly humanPriorityWindowMs = 1200,
+    source: ControlSource = "manual",
+  ) {
+    this.baseSpec = new BaseSpec(stats, this)
+    this.activeSource = source
+
+    this.eventCtrl.SendEventMessage(EventTypes.RegisterLoop, this)
+  }
+
+  get objs() {
+    return undefined
+  }
+
+  setControlSource(source: ControlSource) {
+    this.activeSource = source
+  }
+
+  enqueue(command: ActorCommand) {
+    this.commandQueue.push(command)
+    if (command.issuer === "human") this.lastHumanCommandAt = command.issuedAt
+  }
+
+  update(delta: number): void {
+    this.collectCommands(delta)
+
+    const ctx: CommandContext = {
+      actorId: this.runtime.id,
+      queue: this.commandQueue,
+      consume: () => this.commandQueue.shift(),
+      peek: () => this.commandQueue[0],
+    }
+    this.state = this.state.Update(delta, ctx)
+  }
+
+  applyAction(action: IActionComponent, context?: ActionContext): void {
+    action.apply?.(this, context)
+    action.activate?.(this, context)
+  }
+
+  removeAction(action: IActionComponent, context?: ActionContext): void {
+    action.deactivate?.(this, context)
+    action.remove?.(this)
+  }
+
+  release() {
+    this.eventCtrl.SendEventMessage(EventTypes.DeregisterLoop, this)
+  }
+
+  private collectCommands(delta: number) {
+    const now = Date.now()
+    const candidates: ActorCommand[] = []
+    const sources = this.resolveSources(now)
+    for (const source of sources) {
+      const policy = this.policies[source]
+      if (!policy) continue
+      const generated = policy.tick(delta, this.policyCtx(now))
+      for (const command of generated) candidates.push(command)
+    }
+
+    if (candidates.length === 0) return
+
+    const filtered = candidates.filter((command: ActorCommand) => command.actorId === this.runtime.id)
+    this.commandQueue.push(...this.arbiter(filtered))
+  }
+
+  private resolveSources(now: number): ControlSource[] {
+    if (this.activeSource !== "hybrid") return [this.activeSource]
+
+    const withinHumanWindow = now - this.lastHumanCommandAt <= this.humanPriorityWindowMs
+    return withinHumanWindow ? ["manual", "ai"] : ["ai", "manual"]
+  }
+
+  private policyCtx(now: number): PolicyContext {
+    return {
+      actorId: this.runtime.id,
+      controlSource: this.activeSource,
+      now,
+    }
+  }
+
+  private static defaultArbiter(commands: ActorCommand[]): ActorCommand[] {
+    return [...commands].sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0))
+  }
+}

--- a/src/actors/controllable/controllabledb.ts
+++ b/src/actors/controllable/controllabledb.ts
@@ -1,0 +1,15 @@
+import { ControllableDefinition } from "./controllabletypes"
+
+export class ControllableDb {
+  private readonly db = new Map<string, ControllableDefinition>()
+
+  register(def: ControllableDefinition) {
+    this.db.set(def.id, def)
+  }
+
+  get(id: string): ControllableDefinition {
+    const found = this.db.get(id)
+    if (!found) throw new Error(`unknown controllable id: ${id}`)
+    return found
+  }
+}

--- a/src/actors/controllable/controllables.ts
+++ b/src/actors/controllable/controllables.ts
@@ -1,0 +1,37 @@
+import { ActorCommand } from "./controllabletypes"
+import { ControllableCtrl } from "./controllablectrl"
+
+export class Controllables {
+  private selected = new Set<string>()
+  private readonly actors = new Map<string, ControllableCtrl>()
+
+  register(actorId: string, ctrl: ControllableCtrl) {
+    this.actors.set(actorId, ctrl)
+  }
+
+  unregister(actorId: string) {
+    this.selected.delete(actorId)
+    this.actors.get(actorId)?.release()
+    this.actors.delete(actorId)
+  }
+
+  select(actorId: string, append = false) {
+    if (!append) this.selected.clear()
+    this.selected.add(actorId)
+  }
+
+  clearSelection() {
+    this.selected.clear()
+  }
+
+  issue(command: ActorCommand) {
+    this.actors.get(command.actorId)?.enqueue(command)
+  }
+
+  issueGroup(commands: ActorCommand[]) {
+    commands.forEach((command) => {
+      if (!this.selected.has(command.actorId)) return
+      this.actors.get(command.actorId)?.enqueue(command)
+    })
+  }
+}

--- a/src/actors/controllable/controllabletypes.ts
+++ b/src/actors/controllable/controllabletypes.ts
@@ -1,0 +1,72 @@
+import * as THREE from "three"
+import { ActionDef, IActionComponent } from "@Glibs/types/actiontypes"
+import { StatKey } from "@Glibs/inventory/stat/stattypes"
+
+export type ControllableRole = "ship" | "ally"
+export type ControlSource = "manual" | "ai" | "hybrid"
+
+export type CommandType =
+  | "move"
+  | "attack"
+  | "hold"
+  | "follow"
+  | "patrol"
+  | "useSkill"
+
+export type ActorCommand = {
+  type: CommandType
+  actorId: string
+  issuedAt: number
+  issuer: "human" | "ai" | "script"
+  priority?: number
+  targetId?: string
+  point?: THREE.Vector3
+  payload?: unknown
+}
+
+export interface IControllableState {
+  Init(param?: unknown): void
+  Uninit(): void
+  Update(delta: number, ctx: CommandContext): IControllableState
+}
+
+export type CommandContext = {
+  actorId: string
+  queue: ActorCommand[]
+  consume: () => ActorCommand | undefined
+  peek: () => ActorCommand | undefined
+}
+
+export type ControllableProperty = {
+  id: string
+  role: ControllableRole
+  model: string
+  stats?: Partial<Record<StatKey, number>>
+  actions?: ActionDef[]
+  defaultControlSource?: ControlSource
+  stateFactory: (...params: unknown[]) => IControllableState
+}
+
+export type PolicyContext = {
+  actorId: string
+  controlSource: ControlSource
+  now: number
+}
+
+export interface IControllableRuntime {
+  id: string
+  moveTo?(point: THREE.Vector3): void
+  attackTarget?(targetId: string): void
+  holdPosition?(): void
+  followTarget?(targetId: string): void
+  useSkill?(skillId: string, payload?: unknown): void
+}
+
+export type CommandArbiter = (commands: ActorCommand[]) => ActorCommand[]
+
+export type ControlPolicyMap = Partial<Record<ControlSource, string>>
+
+export type ControllableDefinition = ControllableProperty & {
+  policyMap?: ControlPolicyMap
+  defaultActions?: IActionComponent[]
+}

--- a/src/actors/controllable/createcontrollable.ts
+++ b/src/actors/controllable/createcontrollable.ts
@@ -1,0 +1,38 @@
+import IEventController from "@Glibs/interface/ievent"
+import { ControllableCtrl } from "./controllablectrl"
+import { ControllableDb } from "./controllabledb"
+import { IControllableRuntime } from "./controllabletypes"
+import { IdleControllableState } from "./states/controllablestate"
+import { IControlPolicy } from "./policy/controlpolicy"
+
+export class CreateControllable {
+  constructor(
+    private readonly eventCtrl: IEventController,
+    private readonly db: ControllableDb,
+    private readonly policyFactory: (name: string) => IControlPolicy | undefined,
+  ) {}
+
+  create(id: string, runtime: IControllableRuntime): ControllableCtrl {
+    const def = this.db.get(id)
+
+    const manualName = def.policyMap?.manual ?? "human"
+    const aiName = def.policyMap?.ai ?? "ai"
+
+    const state = def.stateFactory(runtime) ?? new IdleControllableState(runtime)
+
+    return new ControllableCtrl(
+      id,
+      runtime,
+      this.eventCtrl,
+      state,
+      {
+        manual: this.policyFactory(manualName),
+        ai: this.policyFactory(aiName),
+      },
+      def.stats ?? { hp: 100, mp: 20, stamina: 100, attackMelee: 5, attackRanged: 5, defense: 5, speed: 1 },
+      undefined,
+      1200,
+      def.defaultControlSource ?? "manual",
+    )
+  }
+}

--- a/src/actors/controllable/policy/aipolicy.ts
+++ b/src/actors/controllable/policy/aipolicy.ts
@@ -1,0 +1,14 @@
+import { ActorCommand, ControlSource, PolicyContext } from "../controllabletypes"
+import { IControlPolicy } from "./controlpolicy"
+
+export type CommandPlanner = (delta: number, ctx: PolicyContext) => ActorCommand[]
+
+export class AiPolicy implements IControlPolicy {
+  source: ControlSource = "ai"
+
+  constructor(private planner: CommandPlanner) {}
+
+  tick(delta: number, ctx: PolicyContext): ActorCommand[] {
+    return this.planner(delta, ctx)
+  }
+}

--- a/src/actors/controllable/policy/controlpolicy.ts
+++ b/src/actors/controllable/policy/controlpolicy.ts
@@ -1,0 +1,19 @@
+import { ActorCommand, ControlSource, PolicyContext } from "../controllabletypes"
+
+export interface IControlPolicy {
+  source: ControlSource
+  tick(delta: number, ctx: PolicyContext): ActorCommand[]
+  onEvent?(event: unknown, ctx: PolicyContext): void
+}
+
+export class PolicyRegistry {
+  private readonly policies = new Map<string, IControlPolicy>()
+
+  register(name: string, policy: IControlPolicy) {
+    this.policies.set(name, policy)
+  }
+
+  get(name: string): IControlPolicy | undefined {
+    return this.policies.get(name)
+  }
+}

--- a/src/actors/controllable/policy/humanpolicy.ts
+++ b/src/actors/controllable/policy/humanpolicy.ts
@@ -1,0 +1,31 @@
+import * as THREE from "three"
+import { ActorCommand, ControlSource, PolicyContext } from "../controllabletypes"
+import { IControlPolicy } from "./controlpolicy"
+
+export class HumanPolicy implements IControlPolicy {
+  source: ControlSource = "manual"
+  private queue: ActorCommand[] = []
+
+  enqueue(command: Omit<ActorCommand, "issuedAt" | "issuer">) {
+    this.queue.push({
+      ...command,
+      issuedAt: Date.now(),
+      issuer: "human",
+    })
+  }
+
+  move(actorId: string, point: THREE.Vector3, priority = 10) {
+    this.enqueue({ type: "move", actorId, point, priority })
+  }
+
+  attack(actorId: string, targetId: string, priority = 20) {
+    this.enqueue({ type: "attack", actorId, targetId, priority })
+  }
+
+  tick(_delta: number, _ctx: PolicyContext): ActorCommand[] {
+    if (this.queue.length === 0) return []
+    const out = this.queue
+    this.queue = []
+    return out
+  }
+}

--- a/src/actors/controllable/samples/controllabledefs.ts
+++ b/src/actors/controllable/samples/controllabledefs.ts
@@ -1,0 +1,76 @@
+import { ControllableDb } from "../controllabledb"
+import { ControllableDefinition, IControllableRuntime, PolicyContext, ActorCommand } from "../controllabletypes"
+import { IdleControllableState } from "../states/controllablestate"
+import { CommandPlanner } from "../policy/aipolicy"
+
+const now = () => Date.now()
+
+export const ScoutSpaceshipDefinition: ControllableDefinition = {
+  id: "ship.scout",
+  role: "ship",
+  model: "CharShipScout",
+  defaultControlSource: "hybrid",
+  stats: {
+    hp: 180,
+    mp: 80,
+    stamina: 120,
+    attackRanged: 16,
+    defense: 6,
+    speed: 1.6,
+  },
+  policyMap: {
+    manual: "human",
+    ai: "ship-default-ai",
+  },
+  stateFactory: (runtime: unknown) => new IdleControllableState(runtime as IControllableRuntime),
+}
+
+export const EscortAllyDefinition: ControllableDefinition = {
+  id: "ally.escort",
+  role: "ally",
+  model: "CharAllyEscort",
+  defaultControlSource: "hybrid",
+  stats: {
+    hp: 240,
+    mp: 30,
+    stamina: 140,
+    attackMelee: 14,
+    defense: 10,
+    speed: 1.1,
+  },
+  policyMap: {
+    manual: "human",
+    ai: "ally-escort-ai",
+  },
+  stateFactory: (runtime: unknown) => new IdleControllableState(runtime as IControllableRuntime),
+}
+
+export function registerSampleDefinitions(db: ControllableDb) {
+  db.register(ScoutSpaceshipDefinition)
+  db.register(EscortAllyDefinition)
+}
+
+export const defaultShipAiPlanner: CommandPlanner = (_delta: number, ctx: PolicyContext): ActorCommand[] => {
+  // 예시: 일정 주기로 패트롤 명령을 만든다.
+  if (ctx.now % 2000 > 32) return []
+  return [{
+    type: "patrol",
+    actorId: ctx.actorId,
+    issuer: "ai",
+    issuedAt: now(),
+    priority: 5,
+    payload: { radius: 8 },
+  }]
+}
+
+export const defaultEscortAiPlanner: CommandPlanner = (_delta: number, ctx: PolicyContext): ActorCommand[] => {
+  // 예시: 수동 입력이 없을 때 follow 유지 명령.
+  return [{
+    type: "follow",
+    actorId: ctx.actorId,
+    issuer: "ai",
+    issuedAt: now(),
+    priority: 4,
+    targetId: "player-main",
+  }]
+}

--- a/src/actors/controllable/states/controllablestate.ts
+++ b/src/actors/controllable/states/controllablestate.ts
@@ -1,0 +1,41 @@
+import { ActorCommand, CommandContext, IControllableRuntime, IControllableState } from "../controllabletypes"
+
+export class IdleControllableState implements IControllableState {
+  constructor(private runtime: IControllableRuntime) {}
+
+  Init(): void {}
+  Uninit(): void {}
+
+  Update(_delta: number, ctx: CommandContext): IControllableState {
+    const next = ctx.peek()
+    if (!next) return this
+
+    this.applyCommand(next)
+    ctx.consume()
+    return this
+  }
+
+  private applyCommand(command: ActorCommand) {
+    switch (command.type) {
+      case "move":
+        if (command.point) this.runtime.moveTo?.(command.point)
+        return
+      case "attack":
+        if (command.targetId) this.runtime.attackTarget?.(command.targetId)
+        return
+      case "hold":
+        this.runtime.holdPosition?.()
+        return
+      case "follow":
+        if (command.targetId) this.runtime.followTarget?.(command.targetId)
+        return
+      case "useSkill":
+        if (typeof command.payload === "string") {
+          this.runtime.useSkill?.(command.payload, undefined)
+        }
+        return
+      default:
+        return
+    }
+  }
+}

--- a/src/types/globaltypes.ts
+++ b/src/types/globaltypes.ts
@@ -174,6 +174,11 @@ export enum EventTypes {
     FlameInteract = "flameinter",
     DarkParticle = "darkparticle",
 
+    // Controllable actor control
+    SetControlSource = "setcontrolsource",
+    IssueControllableCommand = "issuectrlcmd",
+    IssueControllableGroupCommand = "issuectrlgroupcmd",
+
     GameCenter = "gcenter",
 }
 


### PR DESCRIPTION
### Motivation
- Introduce a unified command-driven architecture to support manual, AI, and hybrid control for actors (e.g. ship/squad) and reduce coupling between input sources and execution. 
- Provide stable command/state/policy types and runtime components so controllers can focus on execution while policies generate commands. 
- Supply sample definitions and documentation to guide integration and iterative improvements (arbiter, queue protection, observability, and networking considerations).

### Description
- Added core types in `src/actors/controllable/controllabletypes.ts` including `ActorCommand`, `ControlSource`, `IControllableRuntime`, `IControllableState`, and `CommandArbiter` to standardize commands and policy contexts. 
- Implemented `ControllableCtrl` in `controllablectrl.ts` as the execution loop with a default priority-based arbiter, hybrid human-priority window (`humanPriorityWindowMs`), command queue, and integration points for `IControlPolicy`. 
- Added policy abstractions and implementations in `policy/` including `IControlPolicy`/`PolicyRegistry`, `HumanPolicy`, and `AiPolicy` with a pluggable planner interface. 
- Added lifecycle and factory utilities: `ControllableDb`, `CreateControllable`, `Controllables` selection/issue manager, and `IdleControllableState` for basic command handling. 
- Added sample definitions and example AI planners in `samples/controllabledefs.ts` and a `registerSampleDefinitions()` helper, plus EventTypes for control events (`SetControlSource`, `IssueControllableCommand`, `IssueControllableGroupCommand`). 
- Included documentation files `docs/controllable-structure-review.md` and `docs/controlled-actor-extension.md` describing priorities, recommended architecture, and next steps for hardening (arbiter policies, queue protection, tests, observability, and networking). 

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c329774ae08323adcb9e199ae9111b)