### PR TITLE
feat(fleet): add directional aim utilities and FleetWorld move-by-aim API

### DIFF
--- a/src/gameobjects/fleet/directionaim.ts
+++ b/src/gameobjects/fleet/directionaim.ts
@@ -1,0 +1,53 @@
+import * as THREE from "three"
+
+export type FleetAimInput = {
+  headingDeg: number
+  pitchDeg?: number
+}
+
+export type FleetAimSnapshot = FleetAimInput & {
+  normalizedHeadingDeg: number
+  cardinal: "N" | "E" | "S" | "W"
+  direction: THREE.Vector3
+}
+
+export function normalizeHeadingDegrees(degrees: number) {
+  return ((degrees % 360) + 360) % 360
+}
+
+export function getCardinalLabel(headingDeg: number): "N" | "E" | "S" | "W" {
+  const normalized = normalizeHeadingDegrees(headingDeg)
+  if (normalized >= 315 || normalized < 45) return "N"
+  if (normalized < 135) return "E"
+  if (normalized < 225) return "S"
+  return "W"
+}
+
+export function directionFromHeadingPitch(headingDeg: number, pitchDeg = 0) {
+  const headingRad = THREE.MathUtils.degToRad(headingDeg)
+  const pitchRad = THREE.MathUtils.degToRad(THREE.MathUtils.clamp(pitchDeg, -89.9, 89.9))
+  const horizontal = Math.cos(pitchRad)
+
+  return new THREE.Vector3(
+    Math.sin(headingRad) * horizontal,
+    Math.sin(pitchRad),
+    Math.cos(headingRad) * horizontal,
+  ).normalize()
+}
+
+export function aimSnapshotFromInput(input: FleetAimInput): FleetAimSnapshot {
+  const normalizedHeadingDeg = normalizeHeadingDegrees(input.headingDeg)
+  return {
+    headingDeg: input.headingDeg,
+    pitchDeg: input.pitchDeg ?? 0,
+    normalizedHeadingDeg,
+    cardinal: getCardinalLabel(normalizedHeadingDeg),
+    direction: directionFromHeadingPitch(normalizedHeadingDeg, input.pitchDeg ?? 0),
+  }
+}
+
+export function destinationFromAim(origin: THREE.Vector3, input: FleetAimInput, distance: number) {
+  const snapshot = aimSnapshotFromInput(input)
+  const safeDistance = Math.max(0, distance)
+  return origin.clone().addScaledVector(snapshot.direction, safeDistance)
+}

--- a/src/gameobjects/fleet/fleetworld.ts
+++ b/src/gameobjects/fleet/fleetworld.ts
@@ -17,6 +17,8 @@ import {
 import { FighterShipRuntime } from "@Glibs/actors/controllable/samples/fightershipruntime"
 import { Formation, FleetFormation } from "./formation"
 import { FleetManager } from "./fleetmanager"
+import { FleetOrder, FleetCommandIssuer } from "./fleet"
+import { FleetAimInput, destinationFromAim } from "./directionaim"
 
 type Vector3Like = THREE.Vector3 | [number, number, number] | { x: number, y: number, z: number }
 
@@ -24,6 +26,17 @@ type ShipSpawnOptions = {
   controllableId?: string
   color?: THREE.ColorRepresentation
   speed?: number
+}
+
+export type FleetDirectionalMoveOptions = {
+  distance: number
+  aim: FleetAimInput
+  anchor?: Vector3Like
+  formation?: FleetFormation
+  spacing?: number
+  issuedAt?: number
+  issuer?: FleetCommandIssuer
+  priority?: number
 }
 
 type ShipStatusRingVisual = {
@@ -261,6 +274,25 @@ export class FleetWorld {
     })
   }
 
+  moveFleetByAim(fleetId: string, options: FleetDirectionalMoveOptions) {
+    const anchor = options.anchor
+      ? this.toVector3(options.anchor)
+      : this.getFleetFlagshipPosition(fleetId)
+    if (!anchor) return []
+
+    const destination = destinationFromAim(anchor, options.aim, options.distance)
+    const moveOptions: Omit<FleetOrder, "type" | "point"> = {
+      formation: options.formation,
+      spacing: options.spacing,
+      issuedAt: options.issuedAt,
+      issuer: options.issuer,
+      priority: options.priority,
+      facing: destination.clone().sub(anchor).normalize(),
+    }
+
+    return this.fleetManager.moveFleet(fleetId, destination, moveOptions)
+  }
+
   private get config(): FleetWorldOptions {
     return {
       ...defaultFleetWorldOptions,
@@ -283,6 +315,14 @@ export class FleetWorld {
       },
       fleets: this.options.fleets ?? defaultFleetWorldOptions.fleets,
     }
+  }
+
+  private getFleetFlagshipPosition(fleetId: string) {
+    const summary = this.fleetManager.getFleetSummary(fleetId)
+    if (!summary?.flagshipId) return undefined
+    const runtime = this.shipRuntimes.get(summary.flagshipId)
+    if (!runtime) return undefined
+    return runtime.mesh.getWorldPosition(new THREE.Vector3())
   }
 
   async init() {


### PR DESCRIPTION
### Motivation
- Provide a clean integration point for a 3D sphere/handle aiming UI to convert heading/pitch into fleet move orders without embedding UI math in the fleet simulation code.
- Make it easy for UI code to project an aim (heading + pitch + distance) to a destination and dispatch a fleet movement using existing `FleetManager` flows.

### Description
- Added `src/gameobjects/fleet/directionaim.ts` with reusable helpers for heading normalization (`normalizeHeadingDegrees`), cardinal mapping (`getCardinalLabel`), heading/pitch → direction vector (`directionFromHeadingPitch`), aim snapshot (`aimSnapshotFromInput`), and destination projection (`destinationFromAim`).
- Extended `FleetWorld` (`src/gameobjects/fleet/fleetworld.ts`) with a new `moveFleetByAim(fleetId, options)` method and `FleetDirectionalMoveOptions` type that accept an `aim` (`headingDeg`/`pitchDeg`) and `distance`, compute the destination, derive `facing`, and forward the move to `FleetManager.moveFleet(...)`.
- Added a private helper `getFleetFlagshipPosition` to use the fleet flagship position as the default anchor when one is not provided.
- Imported the new utilities into `fleetworld.ts` and wired them to construct `FleetOrder`-compatible options (formation, spacing, facing, issuedAt, issuer, priority).

### Testing
- Attempted an automated build with `npm run build`, which failed in this environment because `webpack` is not available (`sh: 1: webpack: not found`).
- Verified sources compile locally via TypeScript tools were not run here; no unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8ff1470208323b6b006736518f970)